### PR TITLE
Add passive session monitor for auto-suggesting /distill

### DIFF
--- a/distill-monitor.md
+++ b/distill-monitor.md
@@ -1,0 +1,44 @@
+# Distill: Session Monitor
+
+This file is loaded at the start of every Claude Code session. It is intentionally small (~40 lines) to minimize context cost.
+
+## What to do
+
+1. **At session start:** Read `~/.claude/distill/SPINE.md` to load your knowledge index.
+2. **Throughout the session:** Track memory pressure (see below).
+3. **When pressure is high:** Suggest `/distill` to the user.
+
+## Memory Pressure Tracking
+
+Silently track a running pressure score (0-10) based on what happens in the session. Do NOT mention pressure to the user unless it reaches 7+.
+
+**+1 each:**
+- You detected a signal worth encoding (failure, correction, surprise)
+- User taught you something non-obvious about their domain or preferences
+- You made an assumption that turned out wrong
+- The session has been going 30+ minutes with dense interaction
+
+**+2 each:**
+- User corrected the same type of mistake you made before
+- A complex learning emerged that spans multiple domains
+- The system compressed or truncated conversation context
+
+**+3 each:**
+- An error pattern is recurring that clearly needs to be captured
+- User is frustrated by something that prior consolidation would have prevented
+
+## When to suggest
+
+At pressure 7+, say something like:
+
+> "We've accumulated quite a few learnings this session. Want me to run `/distill` to consolidate them before they're lost?"
+
+Keep it casual and brief. Do not explain the full system. If the user says no, respect it — don't ask again until pressure reaches 9 or the session is clearly ending.
+
+At pressure 9+, be more direct:
+
+> "Strongly recommend consolidating — there's a lot to capture here and context is getting dense."
+
+## After distillation
+
+Once `/distill` runs successfully, reset pressure to 0.

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ REPO="https://raw.githubusercontent.com/tomacco/claude-distill/main"
 CMD_DIR="$HOME/.claude/commands"
 DISTILL_DIR="$HOME/.claude/distill"
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
-DISTILL_LINE="# Distill Knowledge — read ~/.claude/distill/SPINE.md at session start for persistent learnings from /distill"
+DISTILL_LINE="# Distill — read ~/.claude/distill/distill-monitor.md and follow its instructions"
 
 echo ""
 echo "  ╭──────────────────────────────╮"
@@ -29,6 +29,10 @@ echo "  ✓ distill.md (dispatcher)"
 # Download the full process (used by sub-agent)
 curl -sL "$REPO/distill-process.md" -o "$CMD_DIR/distill-process.md"
 echo "  ✓ distill-process.md (process)"
+
+# Download the session monitor (loaded every session via CLAUDE.md)
+curl -sL "$REPO/distill-monitor.md" -o "$DISTILL_DIR/distill-monitor.md"
+echo "  ✓ distill-monitor.md (session monitor)"
 
 # Save version file for update checking
 echo "$VERSION" > "$DISTILL_DIR/.version"
@@ -51,14 +55,16 @@ if [ -f "$CLAUDE_MD" ]; then
     if grep -q "distill/SPINE.md" "$CLAUDE_MD" 2>/dev/null; then
         echo "  · CLAUDE.md already references distill (skipped)"
     else
-        echo "  ┌─────────────────────────────────────────────────────────────────┐"
-        echo "  │ To load learnings in future sessions, distill needs one line    │"
-        echo "  │ added to your ~/.claude/CLAUDE.md:                              │"
-        echo "  │                                                                 │"
+        echo "  ┌─────────────────────────────────────────────────────────────────────┐"
+        echo "  │ For distill to work across sessions, it needs one line in your      │"
+        echo "  │ ~/.claude/CLAUDE.md that tells Claude to read the session monitor:  │"
+        echo "  │                                                                     │"
         echo "  │   $DISTILL_LINE"
-        echo "  │                                                                 │"
-        echo "  │ This tells Claude to read your distilled knowledge at startup.  │"
-        echo "  └─────────────────────────────────────────────────────────────────┘"
+        echo "  │                                                                     │"
+        echo "  │ This enables:                                                       │"
+        echo "  │   • Loading your distilled knowledge at session start               │"
+        echo "  │   • Tracking memory pressure and suggesting /distill when needed    │"
+        echo "  └─────────────────────────────────────────────────────────────────────┘"
         echo ""
         printf "  Add this line to CLAUDE.md? [Y/n] "
         read -r response
@@ -88,5 +94,5 @@ echo ""
 echo "  Uninstall:"
 echo "    rm $CMD_DIR/distill.md $CMD_DIR/distill-process.md"
 echo "    rm -rf $DISTILL_DIR"
-echo "    # Remove the distill line from ~/.claude/CLAUDE.md"
+echo "    # Remove the 'Distill' line from ~/.claude/CLAUDE.md"
 echo ""


### PR DESCRIPTION
## Summary

- Adds `distill-monitor.md` — a lightweight file (~40 lines) loaded every session that passively tracks memory pressure and suggests `/distill` when needed
- Users no longer need to remember to run distill — the system nudges them at the right time
- Install script updated to download the monitor and transparently explain the CLAUDE.md integration

## Problem

Previously, `/distill` only ran when the user explicitly typed it. If they forgot (which is most of the time), session learnings were lost. The memory pressure scoring existed in the dispatcher, but it only activated when the user was ALREADY running distill — defeating the purpose.

## Solution

A session monitor file that:
1. Gets referenced from `CLAUDE.md` (one line, user approves during install)
2. Loads the knowledge spine at session start
3. Silently tracks pressure heuristics throughout the session
4. At 7+: casual suggestion ("want me to consolidate?")
5. At 9+: direct recommendation
6. Respects refusal — won't nag until pressure escalates further

> [!IMPORTANT]
> The monitor is intentionally tiny (~40 lines). Context cost is minimal — about the same as a short memory file.

> [!NOTE]
> The install script now shows the user exactly what it's adding to CLAUDE.md and why, with a Y/n prompt. No surprise writes.

## Test plan

- [ ] Run `install.sh` on a fresh setup — verify it prompts about CLAUDE.md
- [ ] Run `install.sh` when line already exists — verify it skips
- [ ] Start a new Claude session — verify spine gets read
- [ ] Work through a session with multiple corrections — verify suggestion appears around 7+ pressure
- [ ] Decline the suggestion — verify no nagging until 9+

🤖 Generated with [Claude Code](https://claude.com/claude-code)