### PR TITLE
Align install.sh VERSION constant with VERSION file (0.6.8 -> 0.7.2)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="0.6.8"
+VERSION="0.7.2"
 BUILD="20260515-01"
 REPO="https://raw.githubusercontent.com/tomacco/claude-distill/main"
 CMD_DIR="$HOME/.claude/commands"


### PR DESCRIPTION
## Summary

Fixes a one-character (well, three-character) drift: `install.sh` hardcodes `VERSION="0.6.8"` while the project's `VERSION` file says `0.7.2`. Users running `curl ... | bash` from `main` today see this in the installer output:

```
  Installed
  Version:  v0.6.8        <- stale constant
  Knowledge: ~/.claude/distill/
```

even though the markdown files being downloaded are the actual `v0.7.2` release.

## Why

The 0.7.2 bump (commit `8689d34`, tagged `[version-bump]`) updated the `VERSION` file but didn't touch the hardcoded constant in `install.sh`. So:

- The bash installer logs the wrong version.
- The wrong version is what gets written to `~/.claude/distill/.version`, which the upgrade-detection logic uses on subsequent runs (`Existing installation: v0.6.8 -> v0.7.2` would falsely keep "upgrading" forever).
- The installed `~/.claude/distill/.version` will disagree with the `VERSION` file in the repo a curious user might check.

## Changes

Single line in `install.sh`:

```diff
-VERSION="0.6.8"
+VERSION="0.7.2"
```

Now matches:
- `VERSION` file (`0.7.2`)
- `install.ps1` (`$Version = '0.7.2'`, from PR #2)

## Out of scope (worth thinking about separately)

The deeper issue is that any future version bump requires editing `install.sh` (and `install.ps1`) by hand. Two follow-ups worth considering, both bigger than this PR:

1. **Teach the version-bump script to also update both installers** — preserves the current "version baked into the script" model so installs don't require an extra round-trip.
2. **Have the installers fetch `VERSION` from `main` at runtime** — single source of truth, but adds one network call before the install proper and makes offline / pinned-commit installs harder.

Happy to do either in a follow-up if you have a preference.

## Test plan

Validated against the fork's `fix-install-sh-version` branch (identical diff to what merging this PR would put on `tomacco/main`), executed in a WSL2 Ubuntu environment that already had a `v0.6.8` install present — which also exercises the upgrade-detection path:

- [x] `curl -sL .../install.sh | bash` reports `Version: v0.7.2`
- [x] `cat ~/.claude/distill/.version` equals `0.7.2`

Captured output:

```
  ℹ Existing installation: v0.6.8 → v0.7.2
  Version:  v0.7.2
---
cat ~/.claude/distill/.version:
0.7.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
