### PR TITLE
Fix horizontal scroll on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { overflow-x: hidden; }
 
         body {
             background: var(--void);
@@ -91,6 +92,8 @@
             white-space: pre;
             text-align: center;
             margin-bottom: 3rem;
+            overflow: hidden;
+            max-width: 100vw;
             user-select: none;
             opacity: 0.85;
         }
@@ -896,6 +899,7 @@
             padding: 0 2rem 4rem;
             position: relative;
             z-index: 2;
+            overflow: hidden;
         }
 
         .terminal {


### PR DESCRIPTION
Closes #4

## Problem
Landing page allows horizontal scrolling on mobile despite no visible overflow.

## Root cause
`white-space: pre` elements (neural canvas ASCII art, terminal content) can render wider than the viewport on narrow screens without overflow constraints.

## Fix
- `html { overflow-x: hidden }` — global catch-all
- `.neural-canvas` — add `overflow: hidden` + `max-width: 100vw`
- `.terminal-section` — add `overflow: hidden`

## Test
Check on mobile or Chrome DevTools responsive mode — no horizontal scroll.