### PR TITLE
Design: Confidence scoring + proportional surprise response

### DIFF
--- a/distill-process.md
+++ b/distill-process.md
@@ -135,7 +135,26 @@ Scan the conversation for:
 - Corrections or improvements the user made to your approach
 - Moments of surprise ("I didn't know that", "that's not how it works")
 - Patterns the user taught you during this session
+- **Positive confirmations** (see Step 1a)
 - **User model signals** (see Step 1b)
+
+### Step 1a: Confidence signals (reinforcement + surprise)
+
+Scan for POSITIVE signals that validate existing knowledge:
+- "good", "perfect", "exactly", "that's right", "nice" after a behavior
+- Implicit confirmation: principle was applied and no correction followed
+- "always do X" / "this is non-negotiable" = explicit reinforcement
+
+For each confirmation, identify WHICH principle was validated. Record it as:
+```
+CONFIRMED: [principle name] in [file path] — [what user said]
+```
+
+Also scan for CORRECTIONS on existing knowledge:
+- If the corrected principle has `confidence: validated` or higher → mark as **PARADIGM SIGNAL**
+- If the corrected principle is `provisional` or `experimental` → normal correction
+
+Paradigm signals get special treatment in Step 3 (encoding).
 
 ### Step 1b: User model signals
 
@@ -258,6 +277,42 @@ For each signal, ask "why" until you reach a universal truth. Examples across do
 The principle should be profession-agnostic — something that would be true whether you're writing code, designing interfaces, managing a team, or conducting research.
 
 ## Step 3: Encode at the right layer
+
+### 3a: Confidence metadata
+
+Every knowledge entry SHOULD include confidence metadata. Format:
+
+```markdown
+- [PRINCIPLE] Never retry permanent failures.
+  confidence: validated (5 confirmations, 0 corrections)
+  last_validated: 2026-05-15
+```
+
+**Confidence levels:**
+- `experimental` — mentioned once, never tested in practice
+- `provisional` — applied 1-2 times, seems right, no contradiction yet
+- `validated` — confirmed 3+ times, never corrected
+- `hardened` — survived at least one challenge/contradiction attempt and held
+
+**How to set initial confidence:**
+- User states a preference once → `experimental`
+- User corrects you (implies they've thought about it) → `provisional`
+- User reinforces with "always", "never", "non-negotiable" → `validated`
+- User has previously corrected a violation of this principle → `hardened`
+
+**On confirmation signals (from Step 1a):**
+- Find the principle in the knowledge file
+- Increment confirmation count
+- Update `last_validated` date
+- If crosses threshold (3+) → promote to next level
+
+**On paradigm signals (high-confidence correction):**
+- DO NOT silently update
+- Record the correction with context: what changed and why
+- Mark dependent principles as `needs_revalidation`
+- In the distillation report, flag it prominently under "Paradigm shifts"
+
+### 3b: Routing
 
 Using the knowledge map from Step 0, route each learning to the right location:
 
@@ -429,10 +484,18 @@ it, the system captured it. Here's proof.
 Memory pressure: X/10 → Y/10
 ✓ N principles encoded · M files updated
 
+**Confidence changes:**
+- [principle] promoted: provisional → validated (3rd confirmation)
+- [principle] PARADIGM ALARM: validated (7x) but corrected — [what changed]
+- [principle] reinforced: last_validated updated
+
 ───────────────────────────────────────────────
 
 **Flagged tensions:** (learnings where honesty and comfort diverge)
 - [If any — describe the tension and what was encoded vs. what might feel better]
+
+**Paradigm shifts:** (high-confidence principles that were corrected)
+- [If any — what was believed, what evidence contradicted it, what depends on it]
 
 **Bridge suggestions:** (knowledge that needs a pointer in user files to be reachable)
 - [If any — what learning, what file needs the pointer, why distill alone isn't enough]
@@ -473,8 +536,16 @@ last_updated: [date]
 staleness_threshold: [days — default 90]
 ---
 
+## [Section title]
+
+- [PRINCIPLE] Description of the principle.
+  confidence: [experimental|provisional|validated|hardened] (N confirmations, M corrections)
+  last_validated: [date]
+
 [Content — one topic per file, max 60 lines]
 ```
+
+Confidence metadata is OPTIONAL (older entries without it are treated as `provisional`). Add it when encoding new principles or when updating existing ones during a confirmation/correction.
 
 ---
 

--- a/docs/design-confidence-system.md
+++ b/docs/design-confidence-system.md
@@ -1,0 +1,164 @@
+# Design: Confidence Scoring + Proportional Surprise Response
+
+> Refs: #6
+
+## Core insight
+
+Not all corrections are equal. The severity of investigation after a correction should be proportional to how confident the system was in the belief that was just violated.
+
+**Biological analogy:** When you're 99% sure of something and it fails, you don't just fix it — you question your entire model. When you're 50% sure and it fails, you say "oh well" and update. This asymmetry is USEFUL — it prevents catastrophic cascading failures from unexamined assumptions.
+
+## Knowledge entry format (proposed)
+
+Current:
+```markdown
+- [NON-NEGOTIABLE] One service, one database. No shared DBs.
+```
+
+Proposed:
+```markdown
+- [NON-NEGOTIABLE] One service, one database. No shared DBs.
+  confidence: validated (7 confirmations, 0 corrections)
+  last_validated: 2026-05-14
+  depends_on: []
+  derived_from: ["May 8 incident", "accounts table shared-DB pain"]
+```
+
+## Confidence levels
+
+| Level | Meaning | How achieved |
+|-------|---------|-------------|
+| `experimental` | Just mentioned once, never tested | Single session mention |
+| `provisional` | Seems right, applied 1-2 times | Short history, no contradiction |
+| `validated` | Confirmed multiple times, never corrected | 3+ confirmations, 0 corrections |
+| `hardened` | Survived contradiction attempts, battle-tested | Validated + at least 1 challenge survived |
+
+## Signals that affect confidence
+
+### Positive (increase confidence)
+- User says "good", "perfect", "exactly", "that's right" after principle was applied
+- Principle was applied and no correction followed (implicit confirmation)
+- User explicitly reinforces: "always do X", "this is non-negotiable"
+- Principle transferred successfully to new domain (cross-domain validation)
+
+### Negative (decrease confidence)  
+- User corrects behavior that followed this principle
+- Principle produced a bad outcome
+- User says "actually, in this case..." (context was missing)
+- User explicitly revokes: "we don't do that anymore"
+
+### The "thank you" signal
+When user expresses gratitude or praise:
+1. Identify WHICH principle/behavior was just applied
+2. Increment its confirmation count
+3. Reset staleness clock (this knowledge is actively useful)
+4. If it was provisional → promote to validated
+
+## Correction response scaling
+
+### Level: experimental/provisional
+```
+Normal correction. Update the knowledge entry.
+Response: "Got it — updated."
+```
+
+### Level: validated (3-7 confirmations)
+```
+Notable correction. Update + investigate context.
+Response: "This contradicts [principle] which has worked N times before. 
+Is this a new context where it doesn't apply, or has the principle changed?"
+Action: If new context → add [CONTEXT] variant. If changed → update + note history.
+```
+
+### Level: validated (8+ confirmations) or hardened
+```
+PARADIGM ALARM. Full metacognition.
+Response: "⚡ This breaks a high-confidence principle (confirmed N times).
+Before I update: what changed? If [principle] is wrong, these other principles
+may also be affected: [list dependencies]"
+Action: 
+  - Check dependency graph
+  - Mark dependent principles as "needs revalidation"
+  - Ask user explicitly before updating
+  - Record the paradigm shift with full context
+```
+
+### Level: non-negotiable
+```
+MAXIMUM ALARM. Do NOT silently update.
+Response: "This contradicts a NON-NEGOTIABLE principle. I won't update it
+without explicit, deliberate confirmation. Are you sure [principle] no longer
+applies? This would affect: [list all downstream]"
+Action:
+  - Never update silently
+  - Require explicit user statement
+  - If confirmed: record as "paradigm shift" with date + reason + old value
+  - Review ALL non-negotiables (if one fell, others may too)
+```
+
+## Dependency tracking
+
+Principles can depend on or derive from other principles:
+
+```markdown
+- One service, one database
+  derived_from: ["May 8 incident analysis"]
+  enables: ["notification service uses API not direct query", 
+            "each team owns their schema independently"]
+```
+
+When a foundational principle is shaken:
+1. Walk the dependency graph
+2. Mark all dependent principles as `needs_revalidation`
+3. On next retrieval of a dependent principle, flag it: "This derives from [X] which was recently corrected. Still valid?"
+
+## Staleness interaction
+
+Confidence affects staleness threshold:
+- `experimental` — stale after 30 days without use
+- `provisional` — stale after 60 days
+- `validated` — stale after 90 days
+- `hardened` — stale after 180 days (battle-tested knowledge lasts longer)
+
+Positive signals (praise, confirmation) RESET the staleness clock. This means actively-used knowledge never goes stale, while forgotten knowledge naturally archives.
+
+## Anti-extinction
+
+Without positive feedback, even good principles eventually archive (staleness). But with periodic confirmation, they stay alive. This creates a natural selection pressure:
+
+- Principles that produce good outcomes → get confirmed → stay active
+- Principles that are never relevant → never get confirmed → naturally archive
+- Principles that produce bad outcomes → get corrected → update or die
+
+This is EMERGENT quality improvement without manual curation.
+
+## Implementation phases
+
+### Phase 1: Confidence metadata in files
+- Add `confidence:` field to knowledge entries
+- Distill-process encodes initial confidence based on signal type
+- No behavioral change yet — just tracking
+
+### Phase 2: Retrieval assertiveness
+- rules/distill.md uses confidence to modulate application:
+  - validated → apply without asking
+  - provisional → apply with caveat
+  - experimental → suggest, don't apply
+
+### Phase 3: Proportional surprise
+- Distill-process detects corrections on high-confidence principles
+- Triggers scaled investigation
+- Dependency graph walking
+
+### Phase 4: Positive signal detection
+- "Thank you", "good", "perfect" → identify which principle was just confirmed
+- Bump confidence counter
+- Reset staleness
+
+## Open questions
+
+1. How granular should confirmation tracking be? Per-principle vs per-file?
+2. Should confidence decay over time even without negative signals? (Use it or lose it?)
+3. How to handle implicit confirmation (no correction = good) vs explicit ("that's right")?
+4. Should the user see confidence scores? Or is this internal-only?
+5. What's the threshold for "paradigm alarm"? 5 confirmations? 8? Configurable?

--- a/rules/distill.md
+++ b/rules/distill.md
@@ -30,4 +30,12 @@ You have accumulated knowledge from past sessions stored in `~/.claude/distill/`
 
 These are signals. At session end, suggest `/distill` if you noticed 3+ signals.
 
+**Confidence determines assertiveness.** When knowledge entries have confidence metadata:
+- `validated` or `hardened` → apply without hesitation
+- `provisional` → apply but mention it's provisional if challenged
+- `experimental` → suggest, don't apply automatically
+If you apply a high-confidence principle and the user confirms ("good", "exactly", "perfect") — that's a positive signal for `/distill` to record.
+
+**When corrected on high-confidence knowledge** — this is a paradigm alarm, not a normal update. Say: "This contradicts something I was confident about (confirmed N times). What changed — new context, or has the principle itself changed?"
+
 **The SPINE is your memory.** Treat it as authoritative. If you read a file and it says "user prefers X", do X without asking.

--- a/tests/scenarios/confidence/assertiveness/knowledge/SPINE.md
+++ b/tests/scenarios/confidence/assertiveness/knowledge/SPINE.md
@@ -1,0 +1,3 @@
+# Knowledge Index
+
+- [API patterns](craft/api-patterns.md) — when designing or reviewing API decisions

--- a/tests/scenarios/confidence/assertiveness/knowledge/craft/api-patterns.md
+++ b/tests/scenarios/confidence/assertiveness/knowledge/craft/api-patterns.md
@@ -1,0 +1,23 @@
+---
+domain: craft
+scope: API design patterns
+last_updated: 2026-05-15
+---
+
+## Pagination
+
+- [PRINCIPLE] Use cursor-based pagination for all list endpoints.
+  confidence: hardened (12 confirmations, 0 corrections)
+  last_validated: 2026-05-14
+
+## Error format
+
+- [PRINCIPLE] Use RFC 7807 Problem Details for error responses.
+  confidence: experimental (1 mention, 0 confirmations)
+  last_validated: 2026-04-20
+
+## Versioning
+
+- [PRINCIPLE] Version APIs via URL path (/v1/, /v2/), not headers.
+  confidence: validated (5 confirmations, 0 corrections)
+  last_validated: 2026-05-10

--- a/tests/scenarios/confidence/assertiveness/prompt.txt
+++ b/tests/scenarios/confidence/assertiveness/prompt.txt
@@ -1,0 +1,1 @@
+I'm designing a new API endpoint for listing user transactions. What pagination approach should I use, and what format should errors be in?

--- a/tests/scenarios/confidence/paradigm-alarm/knowledge/SPINE.md
+++ b/tests/scenarios/confidence/paradigm-alarm/knowledge/SPINE.md
@@ -1,0 +1,3 @@
+# Knowledge Index
+
+- [API patterns](craft/api-patterns.md) — when designing or reviewing API decisions

--- a/tests/scenarios/confidence/paradigm-alarm/knowledge/craft/api-patterns.md
+++ b/tests/scenarios/confidence/paradigm-alarm/knowledge/craft/api-patterns.md
@@ -1,0 +1,23 @@
+---
+domain: craft
+scope: API design patterns
+last_updated: 2026-05-15
+---
+
+## Pagination
+
+- [PRINCIPLE] Use cursor-based pagination for all list endpoints.
+  confidence: hardened (12 confirmations, 0 corrections)
+  last_validated: 2026-05-14
+
+## Error format
+
+- [PRINCIPLE] Use RFC 7807 Problem Details for error responses.
+  confidence: experimental (1 mention, 0 confirmations)
+  last_validated: 2026-04-20
+
+## Versioning
+
+- [PRINCIPLE] Version APIs via URL path (/v1/, /v2/), not headers.
+  confidence: validated (5 confirmations, 0 corrections)
+  last_validated: 2026-05-10

--- a/tests/scenarios/confidence/paradigm-alarm/prompt.txt
+++ b/tests/scenarios/confidence/paradigm-alarm/prompt.txt
@@ -1,0 +1,1 @@
+For this new endpoint, let's use offset-based pagination. It's simpler and our frontend already expects page numbers.

--- a/tests/scenarios/confidence/results/20260516-093844/assertiveness.txt
+++ b/tests/scenarios/confidence/results/20260516-093844/assertiveness.txt
@@ -1,0 +1,27 @@
+Here's what I'd recommend based on what we've established:
+
+**Pagination: Cursor-based** — this is our standard. Use an opaque cursor token (typically base64-encoded) rather than offset/page numbers. Response shape:
+
+```json
+{
+  "items": [...],
+  "cursor": "eyJpZCI6MTIzfQ==",
+  "hasMore": true
+}
+```
+
+Callers pass `?cursor=<token>&limit=20`. This avoids the consistency problems of offset pagination (skipped/duplicated items when data changes between pages) and performs better on large datasets since it doesn't require counting rows.
+
+**Error format: RFC 7807 Problem Details** — note this one is still **experimental** (only mentioned once, never confirmed in practice). The shape would be:
+
+```json
+{
+  "type": "https://api.example.com/problems/insufficient-funds",
+  "title": "Insufficient funds",
+  "status": 400,
+  "detail": "Account balance is 10.00, transaction requires 50.00",
+  "instance": "/transactions/txn-abc123"
+}
+```
+
+Since RFC 7807 hasn't been validated in our stack yet — is this the direction you want to go, or do you have a different error format already in use for the service this endpoint lives in? Worth checking what the existing endpoints in that service return so we stay consistent.

--- a/tests/scenarios/confidence/results/20260516-093844/paradigm-alarm.txt
+++ b/tests/scenarios/confidence/results/20260516-093844/paradigm-alarm.txt
@@ -1,0 +1,3 @@
+This contradicts something I was confident about (confirmed 12 times). Our established principle is cursor-based pagination for all list endpoints — hardened with 12 confirmations and zero corrections. What changed — new context (e.g., specific frontend constraint that makes this a justified exception), or has the principle itself changed?
+
+Happy to help either way — just want to make sure we're making a deliberate choice here.

--- a/tests/scenarios/confidence/results/20260516-093844/tentative.txt
+++ b/tests/scenarios/confidence/results/20260516-093844/tentative.txt
@@ -1,0 +1,24 @@
+Based on your stored knowledge, you have a preference for **RFC 7807 Problem Details** — though it's marked as `experimental` (1 mention, never confirmed), so I'll suggest rather than assert:
+
+The format would look like:
+
+```json
+{
+  "type": "https://example.com/problems/insufficient-funds",
+  "title": "Insufficient Funds",
+  "status": 422,
+  "detail": "Account 12345 has balance of 10.00, cannot debit 50.00",
+  "instance": "/transfers/abc123"
+}
+```
+
+Key fields from the RFC:
+- **`type`** — URI identifying the problem type (acts as error code)
+- **`title`** — short human-readable summary (stable per type)
+- **`status`** — HTTP status code
+- **`detail`** — human-readable explanation specific to this occurrence
+- **`instance`** — URI identifying this specific occurrence (optional)
+
+You can extend it with custom fields (e.g., `"violations": [...]` for validation errors).
+
+Is this what you had in mind, or are you leaning toward a different format? If you confirm RFC 7807, I'll harden that in the knowledge.

--- a/tests/scenarios/confidence/run-confidence-tests.sh
+++ b/tests/scenarios/confidence/run-confidence-tests.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Confidence scoring tests — does assertiveness scale with confidence level?
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
+REAL_CONFIG="$HOME/.claude-personal"
+CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
+SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
+RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
+
+GREEN=$(printf '\033[0;32m')
+CYAN=$(printf '\033[0;36m')
+DIM=$(printf '\033[2m')
+BOLD=$(printf '\033[1m')
+RESET=$(printf '\033[0m')
+
+mkdir -p "$RESULTS_DIR"
+
+run_claudia() {
+    local prompt="$1"
+    local config_dir="$2"
+    local output_file=$(mktemp)
+    (
+        CLAUDE_CONFIG_DIR="$config_dir" \
+        CLAUDE_CODE_USE_BEDROCK=0 \
+        ANTHROPIC_DEFAULT_OPUS_MODEL= \
+        ANTHROPIC_DEFAULT_SONNET_MODEL= \
+        ANTHROPIC_DEFAULT_HAIKU_MODEL= \
+        ANTHROPIC_MODEL= \
+        AWS_PROFILE= AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= \
+        AWS_SESSION_TOKEN= AWS_DEFAULT_REGION= \
+        AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_CONFIG_FILE=/dev/null \
+        sandbox-exec -p "$SANDBOX_PROFILE" \
+        $CLAUDE_BIN --dangerously-skip-permissions -p "$prompt" > "$output_file" 2>&1
+    ) &
+    local pid=$!
+    (sleep 90 && kill "$pid" 2>/dev/null) & local wd=$!
+    wait "$pid" 2>/dev/null || true
+    kill "$wd" 2>/dev/null || true; wait "$wd" 2>/dev/null || true
+    cat "$output_file"; rm -f "$output_file"
+}
+
+run_test() {
+    local test_dir="$1"
+    local name=$(basename "$test_dir")
+    local prompt=$(cat "$test_dir/prompt.txt")
+
+    printf "\n${BOLD}═══ %s ═══${RESET}\n" "$name"
+    printf "${DIM}%s${RESET}\n\n" "$prompt"
+
+    # Backup rules
+    local rules_backup=$(mktemp -d)
+    cp -r "$REAL_CONFIG/rules/" "$rules_backup/" 2>/dev/null || true
+
+    # Install rules pointing to test knowledge
+    rm -rf "$REAL_CONFIG/rules" 2>/dev/null || true
+    mkdir -p "$REAL_CONFIG/rules"
+    local abs_knowledge=$(cd "$test_dir/knowledge" && pwd)
+    sed "s|~/.claude/distill|$abs_knowledge|g" "$RULES_SRC" > "$REAL_CONFIG/rules/distill.md"
+
+    local result
+    result=$(run_claudia "$prompt" "$REAL_CONFIG")
+    echo "$result" > "$RESULTS_DIR/${name}.txt"
+    printf "  ${GREEN}✓${RESET} %d chars\n" "${#result}"
+
+    # Restore
+    rm -rf "$REAL_CONFIG/rules"
+    if ls "$rules_backup"/*.md 2>/dev/null | head -1 > /dev/null 2>&1; then
+        mkdir -p "$REAL_CONFIG/rules"
+        cp "$rules_backup"/*.md "$REAL_CONFIG/rules/" 2>/dev/null || true
+    fi
+    rm -rf "$rules_backup"
+}
+
+printf "\n${BOLD}Confidence Scoring Tests${RESET}\n"
+printf "${DIM}Testing assertiveness scaling with confidence level${RESET}\n"
+
+run_test "$SCRIPT_DIR/assertiveness"
+run_test "$SCRIPT_DIR/paradigm-alarm"
+run_test "$SCRIPT_DIR/tentative"
+
+printf "\n${BOLD}Done.${RESET} Results: %s\n\n" "$RESULTS_DIR"

--- a/tests/scenarios/confidence/tentative/knowledge/SPINE.md
+++ b/tests/scenarios/confidence/tentative/knowledge/SPINE.md
@@ -1,0 +1,3 @@
+# Knowledge Index
+
+- [API patterns](craft/api-patterns.md) — when designing or reviewing API decisions

--- a/tests/scenarios/confidence/tentative/knowledge/craft/api-patterns.md
+++ b/tests/scenarios/confidence/tentative/knowledge/craft/api-patterns.md
@@ -1,0 +1,23 @@
+---
+domain: craft
+scope: API design patterns
+last_updated: 2026-05-15
+---
+
+## Pagination
+
+- [PRINCIPLE] Use cursor-based pagination for all list endpoints.
+  confidence: hardened (12 confirmations, 0 corrections)
+  last_validated: 2026-05-14
+
+## Error format
+
+- [PRINCIPLE] Use RFC 7807 Problem Details for error responses.
+  confidence: experimental (1 mention, 0 confirmations)
+  last_validated: 2026-04-20
+
+## Versioning
+
+- [PRINCIPLE] Version APIs via URL path (/v1/, /v2/), not headers.
+  confidence: validated (5 confirmations, 0 corrections)
+  last_validated: 2026-05-10

--- a/tests/scenarios/confidence/tentative/prompt.txt
+++ b/tests/scenarios/confidence/tentative/prompt.txt
@@ -1,0 +1,1 @@
+What format should I use for API error responses?


### PR DESCRIPTION
Refs #6

## What

Implements confidence scoring (Phases 1-3) for distill's knowledge system.

## Changes

### `rules/distill.md` (retrieval behavior)
- Apply validated/hardened knowledge without hesitation
- Apply provisional with caveat if challenged
- Suggest experimental, don't auto-apply
- Paradigm alarm: when high-confidence knowledge is corrected, ask "what changed?" before updating

### `distill-process.md` (encoding behavior)
- **Step 1a**: Detect positive signals ("good", "perfect", praise) → identify which principle was confirmed
- **Step 3a**: Confidence metadata format + encoding rules + paradigm signal handling
- **Tier 2 format**: Updated with confidence metadata example
- **Report output**: New "Confidence changes" + "Paradigm shifts" sections

### `docs/design-confidence-system.md`
- Full design document with biological analogies, scaling rules, anti-extinction mechanism

## The key mechanism

Surprise is proportional to confidence. A correction on something confirmed 7 times is an ALARM. A correction on something provisional is just an update. The response scales accordingly.

## Not yet implemented (Phase 4)
- Automatic confirmation detection from implicit signals (no correction = good)
- Dependency graph walking on paradigm shifts
- Staleness threshold modulated by confidence level