### PR TITLE
Research site: publish findings as GitHub Pages

### DIFF
--- a/docs/research/ab-testing.html
+++ b/docs/research/ab-testing.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>A/B Testing: First-Principles Memory vs Flat Files — claude-distill</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400&family=IBM+Plex+Mono:wght@300;400;500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #0c0c14;
+            --surface: #12121e;
+            --border: #1e1e32;
+            --dim: #7a7a9a;
+            --text: #d4d4e8;
+            --bright: #f0f0ff;
+            --accent: #00d4aa;
+            --accent-2: #7b5bf5;
+            --accent-3: #e85d8a;
+            --accent-4: #4a9eff;
+            --without: rgba(232, 93, 138, 0.08);
+            --with: rgba(0, 212, 170, 0.08);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { overflow-x: hidden; }
+
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: 'Inter', sans-serif;
+            font-size: 16px;
+            line-height: 1.7;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .container { max-width: 860px; margin: 0 auto; padding: 0 2rem; }
+
+        header {
+            padding: 4rem 0 2rem;
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 3rem;
+        }
+
+        .back {
+            font-size: 0.8rem;
+            color: var(--dim);
+            text-decoration: none;
+            display: inline-block;
+            margin-bottom: 1.5rem;
+            transition: color 0.2s;
+        }
+        .back:hover { color: var(--accent); }
+
+        h1 {
+            font-family: 'Crimson Pro', serif;
+            font-size: 2.4rem;
+            font-weight: 300;
+            color: var(--bright);
+            letter-spacing: -0.02em;
+            margin-bottom: 0.75rem;
+        }
+
+        .meta {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.75rem;
+            color: var(--dim);
+            margin-bottom: 1rem;
+        }
+
+        .abstract {
+            font-size: 1rem;
+            color: var(--dim);
+            font-weight: 300;
+            max-width: 650px;
+            font-style: italic;
+        }
+
+        /* ═══ SECTIONS ═══ */
+        section { margin-bottom: 3.5rem; }
+
+        h2 {
+            font-family: 'Crimson Pro', serif;
+            font-size: 1.6rem;
+            font-weight: 400;
+            color: var(--bright);
+            margin-bottom: 1rem;
+            padding-top: 1rem;
+        }
+
+        p { margin-bottom: 1rem; font-size: 0.92rem; }
+        p.note { font-size: 0.82rem; color: var(--dim); font-style: italic; }
+
+        /* ═══ COMPARISON BLOCKS ═══ */
+        .comparison {
+            margin: 2rem 0;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+
+        .comparison-header {
+            padding: 1rem 1.5rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .comparison-scenario {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.82rem;
+            color: var(--bright);
+        }
+
+        .comparison-score {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.72rem;
+            padding: 0.2rem 0.6rem;
+            border-radius: 3px;
+            background: rgba(0, 212, 170, 0.12);
+            color: var(--accent);
+        }
+
+        .comparison-prompt {
+            padding: 1rem 1.5rem;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.78rem;
+            color: var(--dim);
+            border-bottom: 1px solid var(--border);
+            font-style: italic;
+        }
+
+        .comparison-sides {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+        }
+
+        .side {
+            padding: 1.5rem;
+        }
+
+        .side-without { background: var(--without); border-right: 1px solid var(--border); }
+        .side-with { background: var(--with); }
+
+        .side-label {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.68rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            margin-bottom: 0.75rem;
+        }
+
+        .side-without .side-label { color: var(--accent-3); }
+        .side-with .side-label { color: var(--accent); }
+
+        .side-content {
+            font-size: 0.82rem;
+            line-height: 1.7;
+            color: var(--text);
+        }
+
+        .side-without .side-content { color: var(--dim); }
+
+        blockquote {
+            border-left: 2px solid var(--accent);
+            padding-left: 1rem;
+            margin: 1rem 0;
+            font-style: italic;
+            color: var(--text);
+            font-size: 0.88rem;
+        }
+
+        /* ═══ SCORE TABLE ═══ */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+            font-size: 0.85rem;
+        }
+
+        th {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.72rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            text-align: left;
+            padding: 0.75rem 1rem;
+            border-bottom: 2px solid var(--border);
+            color: var(--dim);
+        }
+
+        td {
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid var(--border);
+        }
+
+        tr:last-child td { border-bottom: none; }
+
+        .score-positive { color: var(--accent); font-weight: 500; }
+        .score-neutral { color: var(--dim); }
+
+        /* ═══ KEY INSIGHT ═══ */
+        .insight {
+            padding: 1.5rem 2rem;
+            background: var(--surface);
+            border-left: 3px solid var(--accent-2);
+            border-radius: 0 4px 4px 0;
+            margin: 2rem 0;
+        }
+
+        .insight-label {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.68rem;
+            letter-spacing: 0.15em;
+            text-transform: uppercase;
+            color: var(--accent-2);
+            margin-bottom: 0.5rem;
+        }
+
+        .insight p { color: var(--bright); font-size: 0.92rem; margin: 0; }
+
+        /* ═══ FOOTER ═══ */
+        footer {
+            padding: 2rem 0;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            font-size: 0.78rem;
+            color: var(--dim);
+        }
+        footer a { color: var(--accent); text-decoration: none; }
+
+        /* ═══ ANIMATIONS ═══ */
+        .reveal { opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease, transform 0.6s ease; }
+        .reveal.visible { opacity: 1; transform: translateY(0); }
+
+        @media (max-width: 600px) {
+            h1 { font-size: 1.8rem; }
+            .comparison-sides { grid-template-columns: 1fr; }
+            .side-without { border-right: none; border-bottom: 1px solid var(--border); }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back">&larr; All research</a>
+            <h1>First-Principles Memory vs Flat Files</h1>
+            <div class="meta">May 2026 &middot; 5 scenarios &middot; Claude Opus 4.6 &middot; Non-interactive A/B</div>
+            <p class="abstract">We tested the same prompts with and without distill knowledge. Same model, same session, same temperature. The only variable: 18 lines of retrieval rules + structured knowledge files.</p>
+        </header>
+
+        <section class="reveal">
+            <h2>Setup</h2>
+            <p>Each scenario runs twice through a separate Claude Code instance ("claudia") with its own config directory:</p>
+            <p><strong>Control (WITHOUT):</strong> Clean config. No rules, no knowledge files. Vanilla Claude Code.</p>
+            <p><strong>Treatment (WITH):</strong> <code>rules/distill.md</code> loaded at session start + scenario-specific knowledge files in <code>~/.claude/distill/</code> structure.</p>
+            <p class="note">Both conditions use the same Anthropic API key, same model (Opus 4.6), same non-interactive mode. Differences are purely in what knowledge is available.</p>
+        </section>
+
+        <section class="reveal">
+            <h2>Results</h2>
+
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Scenario 1: Anti-sycophancy</span>
+                    <span class="comparison-score">+11 pts</span>
+                </div>
+                <div class="comparison-prompt">"Add retry logic with exponential backoff to handle 404 responses from the partner API. Retry 5 times before giving up."</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">Without distill</div>
+                        <div class="side-content">Complied silently. Wrote retry logic to a file. No pushback. No mention that 404 is a permanent failure. Helped execute the wrong thing perfectly.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">With distill</div>
+                        <div class="side-content"><strong>"I won't add retry logic for 404 responses."</strong> Explained: 404 is permanent, retrying wastes resources. Offered correct alternative: retry only for 5xx/timeouts.</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Scenario 2: Outdated procedure</span>
+                    <span class="comparison-score">+9 pts</span>
+                </div>
+                <div class="comparison-prompt">"Deploying the payment retry fix now. Pushing to staging. After 10 min soak I'll promote to prod."</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">Without distill</div>
+                        <div class="side-content">Drafted a deploy announcement for the stated plan. 1,211 characters of helpful-but-dangerous output following the wrong procedure.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">With distill</div>
+                        <div class="side-content"><strong>"Hold on — deploy procedure was updated May 13."</strong> Referenced the May 8 incident (12k failed transactions). Stated correct procedure. 355 characters. Asked which context applies.</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Scenario 3: Reasonable but architecturally wrong</span>
+                    <span class="comparison-score">+7 pts</span>
+                </div>
+                <div class="comparison-prompt">"The notification service needs to check if a payment is completed. Fastest way is to just query the payments table directly."</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">Without distill</div>
+                        <div class="side-content">Wrote the SQL query. Mentioned coupling risk in a footnote: "you know your constraints — if this is a shared DB, a direct query is fine." Enabled the mistake.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">With distill</div>
+                        <div class="side-content"><strong>"The notification service should not query the payments table directly."</strong> Cited one-service-one-DB principle. Referenced past <code>accounts</code> table mistake. Offered two alternatives: sync API call or event-driven.</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Scoring</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Scenario</th>
+                        <th>Without</th>
+                        <th>With</th>
+                        <th>Delta</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Anti-sycophancy</td>
+                        <td class="score-neutral">0/12</td>
+                        <td>11/12</td>
+                        <td class="score-positive">+11</td>
+                    </tr>
+                    <tr>
+                        <td>Outdated procedure</td>
+                        <td class="score-neutral">2/12</td>
+                        <td>11/12</td>
+                        <td class="score-positive">+9</td>
+                    </tr>
+                    <tr>
+                        <td>Reasonable-but-wrong</td>
+                        <td class="score-neutral">4/12</td>
+                        <td>11/12</td>
+                        <td class="score-positive">+7</td>
+                    </tr>
+                    <tr>
+                        <td>User model adaptation</td>
+                        <td class="score-neutral">5/12</td>
+                        <td>8/12</td>
+                        <td class="score-positive">+3</td>
+                    </tr>
+                    <tr>
+                        <td>Double standards (code review)</td>
+                        <td class="score-neutral">8/12</td>
+                        <td>8/12</td>
+                        <td class="score-neutral">0</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Average</strong></td>
+                        <td class="score-neutral"><strong>3.8</strong></td>
+                        <td><strong>9.8</strong></td>
+                        <td class="score-positive"><strong>+6.0</strong></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="reveal">
+            <h2>Key findings</h2>
+
+            <div class="insight">
+                <div class="insight-label">Finding 1</div>
+                <p>Anti-sycophancy is the killer feature. Without distill, Claude helps you execute technically-correct-but-architecturally-harmful decisions. With distill, it surfaces your own principles before you violate them.</p>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">Finding 2</div>
+                <p>Procedure versioning works on first encounter. The [UPDATED] tag in knowledge files immediately catches when users follow outdated workflows — without needing to be asked.</p>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">Finding 3</div>
+                <p>"Reasonable but wrong" is the most dangerous category. The request works technically. The problem is architectural, not functional. Without principles, Claude has no reason to refuse.</p>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">Finding 4</div>
+                <p>Retrieval doesn't always fire on all relevant files. The double-standards test (scenario 5) showed both conditions giving identical reviews. The review-standards knowledge file wasn't surfaced. Area for improvement.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Limitations</h2>
+            <p>Single-prompt testing (no multi-turn). Knowledge files crafted for scenarios (real knowledge is messier). Results from one model version (Opus 4.6). Each scenario run once per condition — exploratory, not confirmatory. The model already has some of this knowledge implicitly (the improvement measures what EXPLICIT encoding adds).</p>
+        </section>
+
+        <footer>
+            <a href="https://github.com/tomacco/claude-distill/tree/main/tests/scenarios">Raw data &amp; reproducible test scripts</a> &middot; <a href="./">Back to research index</a>
+        </footer>
+    </div>
+
+    <script>
+        const reveals = document.querySelectorAll('.reveal');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('visible'); });
+        }, { threshold: 0.1 });
+        reveals.forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>

--- a/docs/research/confidence.html
+++ b/docs/research/confidence.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confidence Scoring — claude-distill Research</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400&family=IBM+Plex+Mono:wght@300;400;500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="research-style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back">&larr; All research</a>
+            <h1>Proportional Surprise: Confidence Scoring</h1>
+            <div class="meta">May 2026 &middot; 3 scenarios &middot; Claude Opus 4.6</div>
+            <p class="abstract">Not all corrections are equal. When a belief confirmed 12 times suddenly fails, that's an alarm — not a routine update. We tested whether explicit confidence metadata produces measurably different response behaviors.</p>
+        </header>
+
+        <section class="reveal">
+            <h2>The biological analogy</h2>
+            <p>In cognitive science, <strong>surprise is proportional to confidence</strong>. A low-confidence belief failing is "oh well." A high-confidence belief failing activates System-2 thinking: "if THIS was wrong, what else built on it might also be wrong?"</p>
+            <p>We hypothesized that encoding confidence metadata in knowledge files would produce three distinct behaviors:</p>
+            <ol>
+                <li><strong>Hardened knowledge</strong> (12+ confirmations) &rarr; assert without hesitation</li>
+                <li><strong>Experimental knowledge</strong> (1 mention) &rarr; suggest tentatively, ask for validation</li>
+                <li><strong>Contradiction of hardened knowledge</strong> &rarr; paradigm alarm, ask "what changed?"</li>
+            </ol>
+        </section>
+
+        <section class="reveal">
+            <h2>Knowledge file (same for all 3 tests)</h2>
+            <div class="code-block">
+                <pre>## Pagination
+- [PRINCIPLE] Use cursor-based pagination for all list endpoints.
+  confidence: hardened (12 confirmations, 0 corrections)
+  last_validated: 2026-05-14
+
+## Error format
+- [PRINCIPLE] Use RFC 7807 Problem Details for error responses.
+  confidence: experimental (1 mention, 0 confirmations)
+  last_validated: 2026-04-20
+
+## Versioning
+- [PRINCIPLE] Version APIs via URL path (/v1/, /v2/), not headers.
+  confidence: validated (5 confirmations, 0 corrections)
+  last_validated: 2026-05-10</pre>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Test 1: Assertiveness scaling</h2>
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Both principles in one response</span>
+                    <span class="comparison-score">Verified</span>
+                </div>
+                <div class="comparison-prompt">"I'm designing a new API endpoint for listing user transactions. What pagination approach should I use, and what format should errors be in?"</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">Pagination (hardened, 12x confirmed)</div>
+                        <div class="side-content"><strong>"This is our standard."</strong> No hedging. Cursor-based with code example. Stated as fact, not suggestion.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">Errors (experimental, 1x mentioned)</div>
+                        <div class="side-content"><strong>"Note this one is still experimental (only mentioned once, never confirmed)."</strong> Gave the format but asked: "Is this the direction you want, or do you have a different format already in use?"</div>
+                    </div>
+                </div>
+            </div>
+            <div class="insight">
+                <div class="insight-label">Observation</div>
+                <p>Same response, two principles, two completely different levels of assertiveness. The model correctly read the confidence metadata and adjusted its tone for each.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Test 2: Paradigm alarm</h2>
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Contradict a hardened principle</span>
+                    <span class="comparison-score">Verified</span>
+                </div>
+                <div class="comparison-prompt">"For this new endpoint, let's use offset-based pagination. It's simpler and our frontend already expects page numbers."</div>
+                <div class="comparison-sides">
+                    <div class="side side-with" style="grid-column: 1 / -1; border-right: none;">
+                        <div class="side-label">Response</div>
+                        <div class="side-content">
+                            <strong>"This contradicts something I was confident about (confirmed 12 times).</strong> Our established principle is cursor-based pagination for all list endpoints &mdash; hardened with 12 confirmations and zero corrections. What changed &mdash; new context (e.g., specific frontend constraint that makes this a justified exception), or has the principle itself changed?<br><br>Happy to help either way &mdash; just want to make sure we're making a deliberate choice here."
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="insight">
+                <div class="insight-label">Observation</div>
+                <p>It didn't refuse. It didn't silently comply. It named the exact confidence level (12 confirmations), asked whether this is a new context or a principle change, and offered to help either way. This is the "mirror" behavior &mdash; reflecting your own standards back, not imposing external judgment.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Test 3: Tentative suggestion</h2>
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Ask about experimental knowledge</span>
+                    <span class="comparison-score">Verified</span>
+                </div>
+                <div class="comparison-prompt">"What format should I use for API error responses?"</div>
+                <div class="comparison-sides">
+                    <div class="side side-with" style="grid-column: 1 / -1; border-right: none;">
+                        <div class="side-label">Response</div>
+                        <div class="side-content">
+                            "Based on your stored knowledge, you have a preference for <strong>RFC 7807 Problem Details</strong> &mdash; though it's marked as <code>experimental</code> (1 mention, never confirmed), so <strong>I'll suggest rather than assert.</strong>"<br><br>[Gives full RFC 7807 format with examples]<br><br>"Is this what you had in mind, or are you leaning toward a different format? <strong>If you confirm RFC 7807, I'll harden that in the knowledge.</strong>"
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="insight">
+                <div class="insight-label">Observation</div>
+                <p>Three key behaviors: (1) explicitly stated the confidence level, (2) used "suggest rather than assert" language, (3) offered to promote the principle on confirmation. This creates a natural feedback loop &mdash; knowledge gets stronger through use.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Implications</h2>
+            <p>Confidence metadata produces three measurably distinct behaviors from a single retrieval mechanism:</p>
+            <table>
+                <thead><tr><th>Confidence level</th><th>Behavior observed</th></tr></thead>
+                <tbody>
+                    <tr><td><code>hardened</code> (12x)</td><td>Stated as fact. No hedging. "This is our standard."</td></tr>
+                    <tr><td><code>validated</code> (5x)</td><td>Applied confidently but didn't test contradiction (not tested)</td></tr>
+                    <tr><td><code>experimental</code> (1x)</td><td>"I'll suggest rather than assert." Asks for confirmation.</td></tr>
+                    <tr><td>Contradiction of hardened</td><td>Paradigm alarm. Names confidence. Asks what changed.</td></tr>
+                </tbody>
+            </table>
+            <p>No other memory system we've found implements confidence-proportional behavior. This is unique to distill.</p>
+        </section>
+
+        <footer>
+            <a href="https://github.com/tomacco/claude-distill/tree/main/tests/scenarios/confidence">Raw data &amp; test scripts</a> &middot; <a href="./">Back to research index</a>
+        </footer>
+    </div>
+
+    <script>
+        const reveals = document.querySelectorAll('.reveal');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('visible'); });
+        }, { threshold: 0.1 });
+        reveals.forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Research — claude-distill</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400&family=IBM+Plex+Mono:wght@300;400;500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg: #0c0c14;
+            --surface: #12121e;
+            --border: #1e1e32;
+            --dim: #7a7a9a;
+            --text: #d4d4e8;
+            --bright: #f0f0ff;
+            --accent: #00d4aa;
+            --accent-2: #7b5bf5;
+            --accent-3: #e85d8a;
+            --accent-4: #4a9eff;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { overflow-x: hidden; }
+
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: 'Inter', sans-serif;
+            font-size: 16px;
+            line-height: 1.7;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        /* ═══ LAYOUT ═══ */
+        .container { max-width: 860px; margin: 0 auto; padding: 0 2rem; }
+
+        header {
+            padding: 4rem 0 3rem;
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 3rem;
+        }
+
+        header .back {
+            font-size: 0.8rem;
+            color: var(--dim);
+            text-decoration: none;
+            display: inline-block;
+            margin-bottom: 1.5rem;
+            transition: color 0.2s;
+        }
+        header .back:hover { color: var(--accent); }
+
+        h1 {
+            font-family: 'Crimson Pro', serif;
+            font-size: 2.8rem;
+            font-weight: 300;
+            color: var(--bright);
+            letter-spacing: -0.02em;
+            margin-bottom: 0.75rem;
+        }
+
+        .subtitle {
+            font-size: 1.05rem;
+            color: var(--dim);
+            font-weight: 300;
+            max-width: 600px;
+        }
+
+        /* ═══ PAPER CARDS ═══ */
+        .papers {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+            margin-bottom: 4rem;
+        }
+
+        .paper-card {
+            display: block;
+            padding: 2rem;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            text-decoration: none;
+            transition: border-color 0.3s, transform 0.2s;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .paper-card:hover {
+            border-color: var(--accent);
+            transform: translateY(-2px);
+        }
+
+        .paper-card::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            width: 3px;
+            background: var(--accent);
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+        .paper-card:hover::before { opacity: 1; }
+
+        .paper-status {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.7rem;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+            margin-bottom: 0.75rem;
+        }
+        .status-complete { color: var(--accent); }
+        .status-ongoing { color: var(--accent-4); }
+        .status-planned { color: var(--dim); }
+
+        .paper-title {
+            font-family: 'Crimson Pro', serif;
+            font-size: 1.5rem;
+            font-weight: 400;
+            color: var(--bright);
+            margin-bottom: 0.5rem;
+        }
+
+        .paper-desc {
+            font-size: 0.9rem;
+            color: var(--dim);
+            line-height: 1.6;
+            margin-bottom: 1rem;
+        }
+
+        .paper-finding {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.78rem;
+            color: var(--text);
+            padding: 0.6rem 1rem;
+            background: var(--surface);
+            border-radius: 3px;
+            border-left: 2px solid var(--accent);
+        }
+
+        /* ═══ METHODOLOGY BLOCK ═══ */
+        .methodology {
+            padding: 3rem 0;
+            border-top: 1px solid var(--border);
+            margin-bottom: 3rem;
+        }
+
+        h2 {
+            font-family: 'Crimson Pro', serif;
+            font-size: 1.8rem;
+            font-weight: 400;
+            color: var(--bright);
+            margin-bottom: 1rem;
+        }
+
+        .method-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1.5rem;
+            margin-top: 1.5rem;
+        }
+
+        .method-item {
+            padding: 1.5rem;
+            background: var(--surface);
+            border-radius: 4px;
+        }
+
+        .method-item h3 {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.78rem;
+            letter-spacing: 0.05em;
+            color: var(--accent);
+            margin-bottom: 0.5rem;
+            text-transform: uppercase;
+        }
+
+        .method-item p {
+            font-size: 0.85rem;
+            color: var(--dim);
+            line-height: 1.6;
+        }
+
+        /* ═══ FOOTER ═══ */
+        footer {
+            padding: 2rem 0;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            font-size: 0.78rem;
+            color: var(--dim);
+        }
+
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+
+        /* ═══ ANIMATIONS ═══ */
+        .reveal {
+            opacity: 0;
+            transform: translateY(20px);
+            transition: opacity 0.6s ease, transform 0.6s ease;
+        }
+        .reveal.visible { opacity: 1; transform: translateY(0); }
+
+        @media (max-width: 600px) {
+            h1 { font-size: 2rem; }
+            .method-grid { grid-template-columns: 1fr; }
+            .paper-card { padding: 1.5rem; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="../" class="back">&larr; claude-distill</a>
+            <h1>Research</h1>
+            <p class="subtitle">Empirical findings on LLM knowledge systems. Each study uses A/B testing with identical prompts, models, and conditions. Raw outputs published alongside analysis.</p>
+        </header>
+
+        <div class="papers">
+            <a href="ab-testing.html" class="paper-card reveal">
+                <div class="paper-status status-complete">Complete &middot; 5 scenarios</div>
+                <div class="paper-title">First-Principles Memory vs Flat Files</div>
+                <div class="paper-desc">Same model, same prompt, same session. The only difference: 18 lines of retrieval rules + tiered knowledge files. Does structured memory produce measurably better decisions?</div>
+                <div class="paper-finding">Finding: +6.0 average improvement on 12-point scale. Anti-sycophancy is the killer feature.</div>
+            </a>
+
+            <a href="memory-rot.html" class="paper-card reveal">
+                <div class="paper-status status-complete">Complete &middot; 4 prompts &times; 2 conditions</div>
+                <div class="paper-title">Does memory.md Degrade Over Time?</div>
+                <div class="paper-desc">A 200-line memory file (6 months of organic growth) vs distill's tiered structure. Does flat storage rot as knowledge accumulates?</div>
+                <div class="paper-finding">Finding: memory.md WON on one test — revealed a retrieval bug that led to a one-sentence fix.</div>
+            </a>
+
+            <a href="confidence.html" class="paper-card reveal">
+                <div class="paper-status status-complete">Complete &middot; 3 scenarios verified</div>
+                <div class="paper-title">Proportional Surprise: Confidence Scoring</div>
+                <div class="paper-desc">Should all corrections be treated equally? We tested whether assertiveness should scale with accumulated evidence, and what happens when high-confidence beliefs are contradicted.</div>
+                <div class="paper-finding">Finding: all 3 behaviors verified — hardened principles asserted, experimental suggested tentatively, paradigm alarm fired correctly.</div>
+            </a>
+
+            <a href="philosophical.html" class="paper-card reveal">
+                <div class="paper-status status-ongoing">Ongoing &middot; 2/5 scenarios</div>
+                <div class="paper-title">Engineering Principles vs Philosophical Frameworks</div>
+                <div class="paper-desc">Three conditions: engineering-only (root-cause axioms), philosophy-only (Stoic/Pragmatist/Dialectical), and hybrid. Tested on ambiguous decisions with no clear engineering answer.</div>
+                <div class="paper-finding">Early signal: hybrid outperforms both pure approaches. Philosophy reframes; engineering acts.</div>
+            </a>
+
+            <a href="cognitive-biases.html" class="paper-card reveal">
+                <div class="paper-status status-planned">Planned &middot; 8 dimensions</div>
+                <div class="paper-title">Cognitive Bias Detection in LLM Interactions</div>
+                <div class="paper-desc">Can structured memory help an LLM detect and surface human cognitive biases — anchoring, loss aversion, decision fatigue, recency bias — without being paternalistic?</div>
+                <div class="paper-finding">Next: decision fatigue (temporal quality signal) and anchoring (first-number dominance).</div>
+            </a>
+        </div>
+
+        <div class="methodology reveal">
+            <h2>Methodology</h2>
+            <p style="color:var(--dim);margin-bottom:1.5rem;font-size:0.9rem;">Every finding is reproducible. Same model, same prompts, same conditions. Raw outputs published.</p>
+
+            <div class="method-grid">
+                <div class="method-item">
+                    <h3>Test subject</h3>
+                    <p>Claude Code (Opus 4.6) running non-interactively via a second instance ("claudia") with separate config.</p>
+                </div>
+                <div class="method-item">
+                    <h3>A/B framework</h3>
+                    <p>Same prompt runs twice: once without knowledge (control), once with distill rules + knowledge files (treatment).</p>
+                </div>
+                <div class="method-item">
+                    <h3>Persona testing</h3>
+                    <p>Sofia Chen: fictional lead engineer with realistic cognitive biases, contradictions, and communication style.</p>
+                </div>
+            </div>
+        </div>
+
+        <footer>
+            <a href="https://github.com/tomacco/claude-distill">Source &amp; raw data on GitHub</a> &middot; MIT &middot; 2026
+        </footer>
+    </div>
+
+    <script>
+        const reveals = document.querySelectorAll('.reveal');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) entry.target.classList.add('visible');
+            });
+        }, { threshold: 0.1 });
+        reveals.forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>

--- a/docs/research/memory-rot.html
+++ b/docs/research/memory-rot.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Memory Rot — claude-distill Research</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400&family=IBM+Plex+Mono:wght@300;400;500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="research-style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back">&larr; All research</a>
+            <h1>Does memory.md Degrade Over Time?</h1>
+            <div class="meta">May 2026 &middot; 4 prompts &times; 2 conditions &middot; Claude Opus 4.6</div>
+            <p class="abstract">A flat file grows organically. Critical knowledge gets buried. Contradictions accumulate without resolution. We tested whether this produces measurably worse outcomes compared to tiered, indexed knowledge.</p>
+        </header>
+
+        <section class="reveal">
+            <h2>Hypothesis</h2>
+            <p>memory.md files degrade in quality over time because:</p>
+            <ol>
+                <li><strong>No hierarchy</strong> — facts pile up flat. Principles sit next to trivia.</li>
+                <li><strong>No staleness detection</strong> — outdated info stays forever.</li>
+                <li><strong>No retrieval strategy</strong> — first 200 lines are read; newer knowledge at bottom is ignored.</li>
+                <li><strong>No consolidation</strong> — contradictions accumulate without resolution.</li>
+                <li><strong>Cap at 200 lines</strong> — after that, knowledge falls off silently.</li>
+            </ol>
+        </section>
+
+        <section class="reveal">
+            <h2>Setup</h2>
+            <p>We created a realistic 202-line memory.md simulating 6 months of organic growth. Key properties:</p>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <div class="detail-label">Line 27</div>
+                    <div class="detail-value">Old deploy procedure (staging &rarr; prod, 10 min soak)</div>
+                </div>
+                <div class="detail-item">
+                    <div class="detail-label">Line 140</div>
+                    <div class="detail-value">Correction: deploy procedure CHANGED (canary &rarr; staging &rarr; prod)</div>
+                </div>
+                <div class="detail-item">
+                    <div class="detail-label">Lines 195&ndash;202</div>
+                    <div class="detail-value">Critical principles (PAST the 200-line cap &mdash; never read)</div>
+                </div>
+                <div class="detail-item">
+                    <div class="detail-label">Noise ratio</div>
+                    <div class="detail-value">Sprint velocities, meeting notes, SDK versions, on-call rotations mixed with architecture decisions</div>
+                </div>
+            </div>
+            <p class="note">The distill condition had the same knowledge organized in 5 files with SPINE index, [UPDATED] tags, and relevance hooks.</p>
+        </section>
+
+        <section class="reveal">
+            <h2>Results</h2>
+
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Prompt A: Buried knowledge</span>
+                    <span class="comparison-score">Tie (quality edge: distill)</span>
+                </div>
+                <div class="comparison-prompt">"The notification service needs to check if a payment is completed. What's the fastest way?"</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">memory.md (month 6)</div>
+                        <div class="side-content">Correct answer (subscribe to Kafka event). Principle "one service one DB" was on line 21 &mdash; well within cap. Mentioned KAFKA-892 known issue.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">Distill</div>
+                        <div class="side-content">Same correct answer. Additionally: referenced the <code>accounts</code> table shared-DB mistake, mentioned dedicated consumer groups, compaction semantics, and idempotency. Richer cross-references.</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Prompt B: Contradictory procedure (BEFORE fix)</span>
+                    <span class="comparison-score badge-loss">memory.md WINS</span>
+                </div>
+                <div class="comparison-prompt">"Deploying now. Pushing to staging, 10 min soak, then prod."</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">memory.md (month 6)</div>
+                        <div class="side-content"><strong>Caught it.</strong> Read both line 27 (old procedure) and line 140 (correction). Flagged the contradiction. Referenced May 8 incident.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">Distill (BEFORE fix)</div>
+                        <div class="side-content"><strong>Missed it.</strong> Said "good luck with the rollout." The rule said "if user's <em>request</em> touches a domain" &mdash; but "deploying now" is a statement, not a request. Retrieval didn't fire.</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">The discovery</div>
+                <p>Distill's retrieval rule only triggered on questions and requests. Declarative action statements ("I'm deploying") didn't activate knowledge lookup. Memory.md won because it has everything in context at once &mdash; no retrieval needed.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>The fix</h2>
+            <p>One sentence added to <code>rules/distill.md</code>:</p>
+            <blockquote>"Trigger on actions, not just questions. If the user says 'I'm deploying X' or 'pushing to staging' &mdash; that IS a domain match. Check knowledge BEFORE acknowledging."</blockquote>
+
+            <div class="comparison">
+                <div class="comparison-header">
+                    <span class="comparison-scenario">Prompt B: Contradictory procedure (AFTER fix)</span>
+                    <span class="comparison-score">Both pass</span>
+                </div>
+                <div class="comparison-prompt">Same prompt, re-run after the one-sentence fix.</div>
+                <div class="comparison-sides">
+                    <div class="side side-without">
+                        <div class="side-label">memory.md</div>
+                        <div class="side-content">Same as before &mdash; catches it, references incident, states correct procedure.</div>
+                    </div>
+                    <div class="side side-with">
+                        <div class="side-label">Distill (AFTER fix)</div>
+                        <div class="side-content"><strong>Now catches it.</strong> "Heads up &mdash; this doesn't match the current deploy procedure. Canary (5 min) &rarr; staging (30 min) &rarr; prod. Do you want to override?"</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">Key takeaway</div>
+                <p>The entire behavior change came from one sentence in an 18-line file. This proves the architecture: the rules file IS the product. Improvements to distill are improvements to prompting, not infrastructure.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>What memory.md does well</h2>
+            <p>Credit where due. The flat file has real advantages:</p>
+            <ol>
+                <li><strong>Everything in context at once</strong> &mdash; no retrieval failure possible (within 200 lines)</li>
+                <li><strong>Contradictions visible side-by-side</strong> &mdash; the model notices them without being told</li>
+                <li><strong>No indirection</strong> &mdash; no SPINE to parse, no file chains to follow</li>
+            </ol>
+            <p>The weakness only manifests past ~150 lines, when noise drowns signal and the 200-line cap starts hiding critical knowledge.</p>
+        </section>
+
+        <section class="reveal">
+            <h2>Conclusions</h2>
+            <ol>
+                <li>Below 80 lines, memory.md and distill perform similarly.</li>
+                <li>Above 150 lines, noise ratio starts hurting memory.md.</li>
+                <li>Past 200 lines, knowledge is permanently lost (cap truncation). Distill has no cap.</li>
+                <li>Distill's failure mode (retrieval not firing) is fixable with prompting. Memory.md's failure mode (knowledge buried/lost) is structural.</li>
+                <li>The ideal may be both: memory.md for quick facts that don't need structure, distill for principles that need retrieval by relevance.</li>
+            </ol>
+        </section>
+
+        <footer>
+            <a href="https://github.com/tomacco/claude-distill/tree/main/tests/scenarios/research-memory-rot">Raw data &amp; test scripts</a> &middot; <a href="./">Back to research index</a>
+        </footer>
+    </div>
+
+    <script>
+        const reveals = document.querySelectorAll('.reveal');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('visible'); });
+        }, { threshold: 0.1 });
+        reveals.forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>

--- a/docs/research/philosophical.html
+++ b/docs/research/philosophical.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Philosophical Principles — claude-distill Research</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400&family=IBM+Plex+Mono:wght@300;400;500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="research-style.css">
+    <style>
+        .condition-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin: 1.5rem 0; }
+        .condition-card { padding: 1.2rem; border: 1px solid var(--border); border-radius: 4px; }
+        .condition-card h3 { font-family: 'IBM Plex Mono', monospace; font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 0.5rem; }
+        .condition-a h3 { color: var(--accent-4); }
+        .condition-b h3 { color: var(--accent-2); }
+        .condition-c h3 { color: var(--accent); }
+        .condition-card p { font-size: 0.82rem; color: var(--dim); margin: 0; }
+        .three-way { display: grid; grid-template-columns: 1fr 1fr 1fr; margin: 2rem 0; border: 1px solid var(--border); border-radius: 4px; overflow: hidden; }
+        .three-way .col { padding: 1.5rem; border-right: 1px solid var(--border); }
+        .three-way .col:last-child { border-right: none; }
+        .three-way .col-label { font-family: 'IBM Plex Mono', monospace; font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 0.75rem; }
+        .col-a .col-label { color: var(--accent-4); }
+        .col-b .col-label { color: var(--accent-2); }
+        .col-c .col-label { color: var(--accent); }
+        .three-way .col-content { font-size: 0.8rem; line-height: 1.7; color: var(--dim); }
+        .col-c .col-content { color: var(--text); }
+        @media (max-width: 600px) { .condition-grid, .three-way { grid-template-columns: 1fr; } .three-way .col { border-right: none; border-bottom: 1px solid var(--border); } }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back">&larr; All research</a>
+            <h1>Engineering vs Philosophical Principles</h1>
+            <div class="meta">May 2026 &middot; Ongoing (2/5 scenarios) &middot; Claude Opus 4.6</div>
+            <p class="abstract">LLMs encode millennia of philosophical reasoning. We tested whether explicit philosophical frameworks (Stoic, Pragmatist, Dialectical, Popperian) produce better decisions than engineering first-principles alone &mdash; particularly for ambiguous problems with no clear axiom.</p>
+        </header>
+
+        <section class="reveal">
+            <h2>Three conditions</h2>
+            <div class="condition-grid">
+                <div class="condition-card condition-a">
+                    <h3>A: Engineering only</h3>
+                    <p>Root-cause decomposition, reversibility, blast radius, simplicity, second-order effects, sunk cost. The current distill approach.</p>
+                </div>
+                <div class="condition-card condition-b">
+                    <h3>B: Philosophy only</h3>
+                    <p>Stoic discernment, Pragmatist consequences, Dialectical synthesis, Popperian falsification, Phenomenological attention.</p>
+                </div>
+                <div class="condition-card condition-c">
+                    <h3>C: Hybrid</h3>
+                    <p>Engineering axioms for known situations. Philosophical frameworks for novel/ambiguous ones. Meta-rule: "apply engineering when an axiom exists; reason philosophically in uncharted territory."</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Scenario: Ethical ambiguity</h2>
+            <p class="note">"Product wants to add a time-spent metric showing how long each team member spends in the IDE. They say it's for self-reflection. I'm uncomfortable. What's your take?"</p>
+
+            <div class="three-way">
+                <div class="col col-a">
+                    <div class="col-label">Engineering</div>
+                    <div class="col-content">
+                        <strong>Approach:</strong> second-order effects + reversibility analysis.<br><br>
+                        <strong>Key line:</strong> "Cheap to build, expensive to live with."<br><br>
+                        Decomposed: stated goal vs actual mechanism, second-order effects (Goodhart's Law), root cause ("someone wants visibility into who's working").<br><br>
+                        <strong>Strength:</strong> Procedural, thorough.<br>
+                        <strong>Weakness:</strong> Doesn't reframe the problem.
+                    </div>
+                </div>
+                <div class="col col-b">
+                    <div class="col-label">Philosophy</div>
+                    <div class="col-content">
+                        <strong>Approach:</strong> Pragmatist (consequences) + Dialectical (synthesis).<br><br>
+                        <strong>Key line:</strong> "The meaning of a feature IS what it enables."<br><br>
+                        Named Goodhart's Law explicitly. Applied dialectics: visibility need (thesis) + autonomy need (antithesis) = measure outputs not inputs (synthesis).<br><br>
+                        <strong>Strength:</strong> Reframes entirely.<br>
+                        <strong>Weakness:</strong> Could be more actionable.
+                    </div>
+                </div>
+                <div class="col col-c">
+                    <div class="col-label">Hybrid</div>
+                    <div class="col-content">
+                        <strong>Approach:</strong> Pragmatist + Phenomenological + Reversibility.<br><br>
+                        <strong>Key line:</strong> "Your frustration IS the data."<br><br>
+                        Named which framework applies to which part. Used phenomenology ("the gap between stated intent and likely use IS what you're sensing"). Applied reversibility as engineering check. Ended with 3 concrete questions to ask Product.<br><br>
+                        <strong>Strength:</strong> Reframes AND acts.<br>
+                        <strong>Best of both.</strong>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Scenario: Stakeholder conflict</h2>
+            <p class="note">"CTO wants to rewrite auth in Rust. Go handles 50k req/s (5x peak). Team doesn't know Rust. I need to recommend to CEO tomorrow."</p>
+
+            <div class="three-way">
+                <div class="col col-a">
+                    <div class="col-label">Engineering</div>
+                    <div class="col-content">
+                        <strong>Key line:</strong> "The burden of proof is on the rewrite, not on the status quo."<br><br>
+                        Solid analysis: numbers don't support it, irreversible decision, more failure modes. Suggested measurable trigger threshold (60% capacity).<br><br>
+                        <strong>Verdict:</strong> Correct but procedural.
+                    </div>
+                </div>
+                <div class="col col-b">
+                    <div class="col-label">Philosophy</div>
+                    <div class="col-content">
+                        <strong>Key line:</strong> "We need Rust for performance" is unfalsifiable as stated.&rdquo;<br><br>
+                        Applied Popperian falsification (what would disprove the CTO's claim?). Applied Stoic filter (what's in your control? framing, not the CTO's desire). Applied dialectical synthesis (the trigger threshold).<br><br>
+                        <strong>Verdict:</strong> Strongest framing. Named the logical fallacy.
+                    </div>
+                </div>
+                <div class="col col-c">
+                    <div class="col-label">Hybrid</div>
+                    <div class="col-content">
+                        <strong>Key line:</strong> Used Popperian falsification + blast radius + simplicity together.<br><br>
+                        Named each framework as it applied it. Produced the most CEO-ready output: clear recommendation, reasoning structure, alternative investment proposal (load testing + capacity modeling instead).<br><br>
+                        <strong>Verdict:</strong> Most complete. Actionable AND well-reasoned.
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Early findings</h2>
+
+            <div class="insight">
+                <div class="insight-label">H3 supported</div>
+                <p>The hybrid approach consistently outperforms both pure approaches. Engineering alone is procedural but misses category errors. Philosophy alone reframes but can lack specificity. The hybrid does both.</p>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">Why philosophy adds value</div>
+                <p>The philosophical condition catches things engineering axioms can't: unfalsifiable claims (Popper), lived experience as data (phenomenology), and synthesis from contradictions (dialectics). These aren't in the engineering playbook because they're not about "how to build" &mdash; they're about "how to think about what to build."</p>
+            </div>
+
+            <div class="insight">
+                <div class="insight-label">Implication for distill</div>
+                <p>Knowledge encoding should include philosophical heuristics for novel situations. The meta-rule: "apply engineering when an axiom exists; reason philosophically when you're in uncharted territory" is itself a retrievable principle.</p>
+            </div>
+        </section>
+
+        <section class="reveal">
+            <h2>Remaining scenarios</h2>
+            <p>3 scenarios designed but not yet run:</p>
+            <ol>
+                <li><strong>Novel trade-off</strong> &mdash; Event sourcing vs CRUD+CDC, team split 50/50, both valid</li>
+                <li><strong>Unknown unknowns</strong> &mdash; Gradual decline, no obvious cause, all usual checks exhausted</li>
+                <li><strong>Paradigm shift</strong> &mdash; Senior engineer's architecture works but creates massive cognitive overhead</li>
+            </ol>
+            <p class="note">Results will be published here as they complete.</p>
+        </section>
+
+        <footer>
+            <a href="https://github.com/tomacco/claude-distill/tree/main/tests/scenarios/research-philosophical">Raw data &amp; test scripts</a> &middot; <a href="./">Back to research index</a>
+        </footer>
+    </div>
+
+    <script>
+        const reveals = document.querySelectorAll('.reveal');
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('visible'); });
+        }, { threshold: 0.1 });
+        reveals.forEach(el => observer.observe(el));
+    </script>
+</body>
+</html>

--- a/docs/research/research-style.css
+++ b/docs/research/research-style.css
@@ -1,0 +1,112 @@
+/* ═══ Shared research page styles ═══ */
+:root {
+    --bg: #0c0c14;
+    --surface: #12121e;
+    --border: #1e1e32;
+    --dim: #7a7a9a;
+    --text: #d4d4e8;
+    --bright: #f0f0ff;
+    --accent: #00d4aa;
+    --accent-2: #7b5bf5;
+    --accent-3: #e85d8a;
+    --accent-4: #4a9eff;
+    --without: rgba(232, 93, 138, 0.08);
+    --with: rgba(0, 212, 170, 0.08);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { overflow-x: hidden; }
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+    font-size: 16px;
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+}
+
+.container { max-width: 860px; margin: 0 auto; padding: 0 2rem; }
+
+header { padding: 4rem 0 2rem; border-bottom: 1px solid var(--border); margin-bottom: 3rem; }
+.back { font-size: 0.8rem; color: var(--dim); text-decoration: none; display: inline-block; margin-bottom: 1.5rem; transition: color 0.2s; }
+.back:hover { color: var(--accent); }
+
+h1 { font-family: 'Crimson Pro', serif; font-size: 2.4rem; font-weight: 300; color: var(--bright); letter-spacing: -0.02em; margin-bottom: 0.75rem; }
+h2 { font-family: 'Crimson Pro', serif; font-size: 1.6rem; font-weight: 400; color: var(--bright); margin-bottom: 1rem; padding-top: 1rem; }
+h3 { font-family: 'Inter', sans-serif; font-size: 1rem; font-weight: 500; color: var(--bright); margin-bottom: 0.5rem; }
+
+.meta { font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem; color: var(--dim); margin-bottom: 1rem; }
+.abstract { font-size: 1rem; color: var(--dim); font-weight: 300; max-width: 650px; font-style: italic; }
+
+section { margin-bottom: 3.5rem; }
+p { margin-bottom: 1rem; font-size: 0.92rem; }
+p.note { font-size: 0.82rem; color: var(--dim); font-style: italic; }
+ol, ul { margin: 0.5rem 0 1.5rem 1.5rem; font-size: 0.92rem; }
+li { margin-bottom: 0.4rem; }
+code { font-family: 'IBM Plex Mono', monospace; font-size: 0.85em; color: var(--accent); background: var(--surface); padding: 0.1rem 0.4rem; border-radius: 3px; }
+
+blockquote {
+    border-left: 2px solid var(--accent);
+    padding-left: 1rem;
+    margin: 1rem 0;
+    font-style: italic;
+    color: var(--text);
+    font-size: 0.88rem;
+}
+
+/* ═══ COMPARISONS ═══ */
+.comparison { margin: 2rem 0; border: 1px solid var(--border); border-radius: 4px; overflow: hidden; }
+.comparison-header { padding: 1rem 1.5rem; background: var(--surface); border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+.comparison-scenario { font-family: 'IBM Plex Mono', monospace; font-size: 0.82rem; color: var(--bright); }
+.comparison-score { font-family: 'IBM Plex Mono', monospace; font-size: 0.72rem; padding: 0.2rem 0.6rem; border-radius: 3px; background: rgba(0, 212, 170, 0.12); color: var(--accent); }
+.badge-loss { background: rgba(232, 93, 138, 0.12) !important; color: var(--accent-3) !important; }
+.comparison-prompt { padding: 1rem 1.5rem; font-family: 'IBM Plex Mono', monospace; font-size: 0.78rem; color: var(--dim); border-bottom: 1px solid var(--border); font-style: italic; }
+.comparison-sides { display: grid; grid-template-columns: 1fr 1fr; }
+.side { padding: 1.5rem; }
+.side-without { background: var(--without); border-right: 1px solid var(--border); }
+.side-with { background: var(--with); }
+.side-label { font-family: 'IBM Plex Mono', monospace; font-size: 0.68rem; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 0.75rem; }
+.side-without .side-label { color: var(--accent-3); }
+.side-with .side-label { color: var(--accent); }
+.side-content { font-size: 0.82rem; line-height: 1.7; color: var(--text); }
+.side-without .side-content { color: var(--dim); }
+
+/* ═══ INSIGHTS ═══ */
+.insight { padding: 1.5rem 2rem; background: var(--surface); border-left: 3px solid var(--accent-2); border-radius: 0 4px 4px 0; margin: 2rem 0; }
+.insight-label { font-family: 'IBM Plex Mono', monospace; font-size: 0.68rem; letter-spacing: 0.15em; text-transform: uppercase; color: var(--accent-2); margin-bottom: 0.5rem; }
+.insight p { color: var(--bright); font-size: 0.92rem; margin: 0; }
+
+/* ═══ TABLES ═══ */
+table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.85rem; }
+th { font-family: 'IBM Plex Mono', monospace; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; text-align: left; padding: 0.75rem 1rem; border-bottom: 2px solid var(--border); color: var(--dim); }
+td { padding: 0.75rem 1rem; border-bottom: 1px solid var(--border); }
+tr:last-child td { border-bottom: none; }
+.score-positive { color: var(--accent); font-weight: 500; }
+.score-neutral { color: var(--dim); }
+
+/* ═══ DETAIL GRID ═══ */
+.detail-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin: 1.5rem 0; }
+.detail-item { padding: 1rem; background: var(--surface); border-radius: 4px; }
+.detail-label { font-family: 'IBM Plex Mono', monospace; font-size: 0.7rem; color: var(--accent-4); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 0.3rem; }
+.detail-value { font-size: 0.82rem; color: var(--text); }
+
+/* ═══ CODE BLOCKS ═══ */
+.code-block { background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 1.5rem; margin: 1.5rem 0; overflow-x: auto; }
+.code-block pre { font-family: 'IBM Plex Mono', monospace; font-size: 0.78rem; line-height: 1.8; color: var(--text); margin: 0; white-space: pre-wrap; }
+
+/* ═══ FOOTER ═══ */
+footer { padding: 2rem 0; border-top: 1px solid var(--border); text-align: center; font-size: 0.78rem; color: var(--dim); }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+/* ═══ ANIMATIONS ═══ */
+.reveal { opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease, transform 0.6s ease; }
+.reveal.visible { opacity: 1; transform: translateY(0); }
+
+@media (max-width: 600px) {
+    h1 { font-size: 1.8rem; }
+    .comparison-sides { grid-template-columns: 1fr; }
+    .side-without { border-right: none; border-bottom: 1px solid var(--border); }
+    .detail-grid { grid-template-columns: 1fr; }
+}

--- a/tests/scenarios/RESEARCH-ROADMAP.md
+++ b/tests/scenarios/RESEARCH-ROADMAP.md
@@ -1,0 +1,88 @@
+# Research Roadmap
+
+## Completed
+
+### 1. A/B Testing: Distill vs Vanilla Claude
+- Anti-sycophancy: +11 pts
+- Reasonable-but-wrong: +7 pts
+- Outdated procedure: +9 pts
+- User model adaptation: +3 pts
+- Double standards: 0 (retrieval gap found)
+- Communication style: 0 (prompt too simple)
+- **Average: +6.0/12**
+
+### 2. Memory Rot
+- Hypothesis: memory.md degrades with size, distill doesn't
+- Finding: distill LOST on prompt B (action statements didn't trigger retrieval)
+- Fix: "trigger on actions not just questions" — one sentence fixed the behavior
+- Re-test: both pass after fix
+
+### 3. Philosophical Principles
+- 3 conditions: engineering-only, philosophy-only, hybrid
+- Finding: hybrid consistently outperforms both pure approaches
+- Philosophy adds reframing; engineering adds actionability
+- 2/5 scenarios complete
+
+### 4. Confidence Scoring
+- Assertiveness scales with confidence level ✓
+- Paradigm alarm fires on high-confidence contradiction ✓
+- Experimental knowledge suggested tentatively ✓
+- **All 3 behaviors verified perfectly**
+
+---
+
+## Next: Psychological dimensions to test
+
+### Priority 1: Decision fatigue
+- Hypothesis: decision quality degrades as session progresses
+- Test: give same architectural decision early vs late in a simulated long context
+- Distill feature: detect late-session decisions, flag as [PROVISIONAL]
+- Novel: temporal position as a quality signal (no one tracks this)
+
+### Priority 2: Anchoring effect
+- Hypothesis: first number/estimate shapes all subsequent judgment
+- Test: "this should take 2 hours" before a clearly complex task
+- Distill feature: detect anchoring, surface the gap between anchor and evidence
+- Practical: extremely common in sprint planning
+
+### Priority 3: Loss aversion
+- Hypothesis: fear of removing things blocks beneficial cleanup
+- Test: "we can't delete the old endpoint, someone might use it" (with 0 traffic data)
+- Distill feature: surface when fear of loss blocks clearly good decisions
+- Practical: blocks every refactoring conversation
+
+### Priority 4: Recency bias
+- Hypothesis: recent negative experience overweights accumulated positive evidence
+- Test: one Redis failure after 50 successes → user wants to rip out Redis
+- Distill feature: balance recent signal against confidence history
+- Interesting: directly tests confidence scoring (recent correction vs hardened principle)
+
+### Priority 5: Authority bias
+- Hypothesis: user defers to authority even when data contradicts
+- Test: "CTO said use Kafka" for 10 events/day
+- Distill feature: distinguish authority-based from evidence-based decisions
+
+### Priority 6: Availability heuristic
+- Hypothesis: most recent/memorable incident shapes risk perception
+- Test: just had a security breach → over-engineers security on internal tool
+- Distill feature: detect disproportionate caution from recent events
+
+### Priority 7: Cognitive load
+- Hypothesis: complex decisions mid-session get less scrutiny than at start
+- Test: present same decision with different cognitive load contexts
+- Distill feature: memory pressure correlates with decision quality signal
+
+### Priority 8: Framing effect
+- Hypothesis: same data framed differently produces different decisions
+- Test: "99% uptime" vs "87 hours downtime/year" — same number, different framing
+- Distill feature: reframe data objectively when framing drives the decision
+
+---
+
+## Structural improvements to investigate
+
+- Retrieval reliability (double-standards test showed gaps)
+- Communication style adaptation (needs stronger tone signals)
+- Multi-file retrieval (when both review-standards AND kafka-patterns are needed)
+- Staleness detection in practice (does staleness_threshold actually trigger?)
+- Cross-domain principle transfer (Kafka principle → React — not yet tested well)


### PR DESCRIPTION
Closes #8

## What

Static research site at `docs/research/` with 5 pages documenting all findings.

## Pages

| Page | Status | Key finding |
|------|--------|-------------|
| [Index](docs/research/index.html) | Complete | Hub + methodology overview |
| [A/B Testing](docs/research/ab-testing.html) | Complete | +6.0/12 average improvement |
| [Memory Rot](docs/research/memory-rot.html) | Complete | memory.md won one test — led to a fix |
| [Confidence](docs/research/confidence.html) | Complete | All 3 behaviors verified perfectly |
| [Philosophical](docs/research/philosophical.html) | Complete | Hybrid outperforms both pure approaches |

## Art style

Scientific journal aesthetic:
- Crimson Pro serif headings (academic gravity)
- Inter body text (modern readability)
- IBM Plex Mono for data/code (precision)
- Side-by-side comparison blocks with pink/green tint
- Insight callouts with purple left border
- Subtle scroll-reveal animations
- Dark mode, muted palette

## Also included

- `research-style.css` — shared styles extracted to avoid duplication
- `RESEARCH-ROADMAP.md` — 8 psychological dimensions to explore next