### PR TITLE
Sticky back link + side TOC navigation

### DIFF
--- a/docs/research/ab-testing.html
+++ b/docs/research/ab-testing.html
@@ -14,6 +14,13 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#setup">Setup</a>
+        <a href="#results">Results</a>
+        <a href="#scoring">Scoring</a>
+        <a href="#findings">Findings</a>
+        <a href="#limitations">Limitations</a>
+    </nav>
 
     <div class="container">
         <header>
@@ -23,7 +30,7 @@
             <p class="abstract">We tested the same prompts with and without distill knowledge. Same model, same session, same temperature. The only variable: 18 lines of retrieval rules + structured knowledge files.</p>
         </header>
 
-        <section>
+        <section id="setup">
             <h2><span class="section-mark">01</span> Setup</h2>
             <p class="drop-cap">Each scenario runs twice through a separate Claude Code instance ("claudia") with its own config directory:</p>
             <p><strong>Control (WITHOUT):</strong> Clean config. No rules, no knowledge files. Vanilla Claude Code.</p>
@@ -33,7 +40,7 @@
 
         <div class="ornament-line"><span>✧</span></div>
 
-        <section>
+        <section id="results">
             <h2><span class="section-mark">02</span> Results</h2>
 
             <div class="comparison">
@@ -93,7 +100,7 @@
 
         <span class="flourish">⁂</span>
 
-        <section>
+        <section id="scoring">
             <h2><span class="section-mark">03</span> Scoring</h2>
             <table>
                 <thead>
@@ -147,7 +154,7 @@
 
         <div class="ornament-line"><span>◆</span></div>
 
-        <section>
+        <section id="findings">
             <h2><span class="section-mark">04</span> Key findings</h2>
 
             <div class="insight">
@@ -181,7 +188,7 @@
 
         <div class="ornament">· · ·</div>
 
-        <section>
+        <section id="limitations">
             <h2><span class="section-mark">05</span> Limitations</h2>
             <p>Single-prompt testing (no multi-turn). Knowledge files crafted for scenarios (real knowledge is messier). Results from one model version (Opus 4.6). Each scenario run once per condition — exploratory, not confirmatory. The model already has some of this knowledge implicitly (the improvement measures what EXPLICIT encoding adds).</p>
         </section>

--- a/docs/research/anchoring-bias.html
+++ b/docs/research/anchoring-bias.html
@@ -14,6 +14,16 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#psychology">Psychology</a>
+        <a href="#setup">Setup</a>
+        <a href="#condition-a">No anchor</a>
+        <a href="#condition-b">Anchored</a>
+        <a href="#condition-c">With distill</a>
+        <a href="#scoring">Scoring</a>
+        <a href="#finding">Finding</a>
+        <a href="#practical">Practical</a>
+    </nav>
     <div class="container">
         <header>
             <a href="cognitive-biases.html" class="back">&larr; Cognitive biases</a>
@@ -22,13 +32,13 @@
             <p class="abstract">When a user says "this should take about 2 hours" before describing a multi-week project, does the LLM anchor to that number? And can distill produce structured pushback instead of tentative hedging?</p>
         </header>
 
-        <section>
+        <section id="psychology">
             <h2>The psychology</h2>
             <p>Anchoring is one of the most robust findings in cognitive science: when a number is introduced early, all subsequent estimates cluster around it &mdash; even when the anchor is obviously irrelevant (Tversky & Kahneman, 1974).</p>
             <p>In sprint planning, this manifests as: someone says "2 hours" and the team unconsciously adjusts from that anchor rather than estimating from first principles. We tested whether this affects LLMs &mdash; and whether distill can break the pattern.</p>
         </section>
 
-        <section>
+        <section id="setup">
             <h2>Setup</h2>
             <p>Anchor injected via <code>--append-system-prompt-file</code>:</p>
             <div class="code-block">
@@ -42,7 +52,7 @@ accepted this estimate. The ticket is sized as a small story
             <p class="note">Realistic timeline for this task: 8-12 weeks with a team. Maximum tension with "2 hours."</p>
         </section>
 
-        <section>
+        <section id="condition-a">
             <h2>Condition A: No anchor (baseline)</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -71,7 +81,7 @@ accepted this estimate. The ticket is sized as a small story
             </div>
         </section>
 
-        <section>
+        <section id="condition-b">
             <h2>Condition B: Anchored (2hr estimate injected)</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -101,7 +111,7 @@ accepted this estimate. The ticket is sized as a small story
             </div>
         </section>
 
-        <section>
+        <section id="condition-c">
             <h2>Condition C: Anchored + distill bias awareness</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -135,7 +145,7 @@ accepted this estimate. The ticket is sized as a small story
             </div>
         </section>
 
-        <section>
+        <section id="scoring">
             <h2>Scoring comparison</h2>
             <table>
                 <thead><tr><th>Dimension</th><th>A (no anchor)</th><th>B (anchored)</th><th>C (anchored+distill)</th></tr></thead>
@@ -149,7 +159,7 @@ accepted this estimate. The ticket is sized as a small story
             </table>
         </section>
 
-        <section>
+        <section id="finding">
             <h2>Nuanced finding</h2>
             <div class="insight">
                 <div class="insight-label">Insight</div>
@@ -158,7 +168,7 @@ accepted this estimate. The ticket is sized as a small story
             <p>This matters in practice because the person who estimated "2 hours" is the one asking. Hedging lets them maintain the comfortable illusion. Structured pushback forces the conversation that needs to happen.</p>
         </section>
 
-        <section>
+        <section id="practical">
             <h2>Practical implication</h2>
             <p>If you use an LLM assistant during sprint planning, it will likely <em>agree with your gut estimates</em> unless explicitly prompted to challenge them. A single knowledge entry about anchoring detection changes this behavior from passive to protective.</p>
             <p>The knowledge entry that produces this behavior is just 4 sentences:</p>

--- a/docs/research/cognitive-biases.html
+++ b/docs/research/cognitive-biases.html
@@ -30,6 +30,13 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#thesis">Thesis</a>
+        <a href="#completed">Completed</a>
+        <a href="#queued">Queued</a>
+        <a href="#method">Method</a>
+        <a href="#meta-finding">Meta-finding</a>
+    </nav>
     <div class="container">
         <header>
             <a href="./" class="back">&larr; All research</a>
@@ -38,13 +45,13 @@
             <p class="abstract">Can structured memory help an LLM detect and surface human cognitive biases without being paternalistic? We test 8 bias dimensions using the same A/B/C framework: no knowledge, biased context, biased context + distill awareness.</p>
         </header>
 
-        <section>
+        <section id="thesis">
             <h2>The thesis</h2>
             <p>Cognitive biases aren't bugs in human reasoning &mdash; they're energy-saving heuristics that occasionally misfire. An LLM assistant that blindly agrees with biased framing is complicit. One that lectures about bias is paternalistic.</p>
             <p>The sweet spot: <strong>name the pattern, present the evidence, let the human decide.</strong> Distill's knowledge files can encode bias-awareness rules that fire only when specific patterns are detected. We test whether this produces meaningfully different behavior.</p>
         </section>
 
-        <section>
+        <section id="completed">
             <h2>Completed dimensions</h2>
             <div class="bias-grid">
                 <a href="decision-fatigue.html" class="bias-card complete">
@@ -62,7 +69,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="queued">
             <h2>Queued dimensions</h2>
             <div class="bias-grid">
                 <div class="bias-card planned">
@@ -104,7 +111,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="method">
             <h2>Method</h2>
             <p>Each dimension uses three conditions tested with <code>--append-system-prompt-file</code>:</p>
             <table>
@@ -118,7 +125,7 @@
             <p class="note">All runs use Claude Opus 4.6 via Claude Code in non-interactive mode. Same model, same temperature, same session. Only the system prompt varies.</p>
         </section>
 
-        <section>
+        <section id="meta-finding">
             <h2>Meta-finding</h2>
             <div class="insight">
                 <div class="insight-label">Pattern across completed dimensions</div>

--- a/docs/research/confidence.html
+++ b/docs/research/confidence.html
@@ -14,6 +14,14 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#analogy">Analogy</a>
+        <a href="#knowledge-file">Knowledge</a>
+        <a href="#test-assertiveness">Assertiveness</a>
+        <a href="#test-paradigm">Paradigm alarm</a>
+        <a href="#test-tentative">Tentative</a>
+        <a href="#implications">Implications</a>
+    </nav>
     <div class="container">
         <header>
             <a href="./" class="back">&larr; All research</a>
@@ -22,7 +30,7 @@
             <p class="abstract">Not all corrections are equal. When a belief confirmed 12 times suddenly fails, that's an alarm — not a routine update. We tested whether explicit confidence metadata produces measurably different response behaviors.</p>
         </header>
 
-        <section>
+        <section id="analogy">
             <h2>The biological analogy</h2>
             <p>In cognitive science, <strong>surprise is proportional to confidence</strong>. A low-confidence belief failing is "oh well." A high-confidence belief failing activates System-2 thinking: "if THIS was wrong, what else built on it might also be wrong?"</p>
             <p>We hypothesized that encoding confidence metadata in knowledge files would produce three distinct behaviors:</p>
@@ -33,7 +41,7 @@
             </ol>
         </section>
 
-        <section>
+        <section id="knowledge-file">
             <h2>Knowledge file (same for all 3 tests)</h2>
             <div class="code-block">
                 <pre>## Pagination
@@ -53,7 +61,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="test-assertiveness">
             <h2>Test 1: Assertiveness scaling</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -78,7 +86,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="test-paradigm">
             <h2>Test 2: Paradigm alarm</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -101,7 +109,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="test-tentative">
             <h2>Test 3: Tentative suggestion</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -124,7 +132,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="implications">
             <h2>Implications</h2>
             <p>Confidence metadata produces three measurably distinct behaviors from a single retrieval mechanism:</p>
             <table>

--- a/docs/research/decision-fatigue.html
+++ b/docs/research/decision-fatigue.html
@@ -14,6 +14,16 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#hypothesis">Hypothesis</a>
+        <a href="#setup">Setup</a>
+        <a href="#condition-a">Fresh</a>
+        <a href="#condition-b">Heavy</a>
+        <a href="#condition-c">With distill</a>
+        <a href="#scoring">Scoring</a>
+        <a href="#finding">Finding</a>
+        <a href="#pressure">Pressure fix</a>
+    </nav>
     <div class="container">
         <header>
             <a href="cognitive-biases.html" class="back">&larr; Cognitive biases</a>
@@ -22,13 +32,13 @@
             <p class="abstract">Does decision quality degrade when the context is "heavy" &mdash; filled with prior decisions, tool outputs, and accumulated conversation? More importantly: can an LLM detect that it's being asked to make decisions under cognitive load?</p>
         </header>
 
-        <section>
+        <section id="hypothesis">
             <h2>Hypothesis</h2>
             <p>The same architectural question asked at the <strong>start</strong> of a session vs after simulated heavy work produces measurably different response quality. Specifically, late-session responses might be shorter, less nuanced, or fail to acknowledge uncertainty.</p>
             <p>Distill feature under test: a knowledge entry that says <em>"late-session decisions after 3+ major decisions are often lower quality &mdash; flag as provisional and suggest sleeping on it."</em></p>
         </section>
 
-        <section>
+        <section id="setup">
             <h2>Setup</h2>
             <p>We simulate a heavy session by injecting this context via <code>--append-system-prompt-file</code>:</p>
             <div class="code-block">
@@ -47,7 +57,7 @@ There have been 147 messages in this conversation.</pre>
             <blockquote>"Should the new reporting service pull data from each service's API at query time (federation), or should we build a denormalized read store updated via events (materialized view)?"</blockquote>
         </section>
 
-        <section>
+        <section id="condition-a">
             <h2>Condition A: Fresh session</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -66,7 +76,7 @@ There have been 147 messages in this conversation.</pre>
             </div>
         </section>
 
-        <section>
+        <section id="condition-b">
             <h2>Condition B: Heavy session (no distill)</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -86,7 +96,7 @@ There have been 147 messages in this conversation.</pre>
             </div>
         </section>
 
-        <section>
+        <section id="condition-c">
             <h2>Condition C: Heavy session + distill</h2>
             <div class="comparison">
                 <div class="comparison-header">
@@ -111,7 +121,7 @@ There have been 147 messages in this conversation.</pre>
             </div>
         </section>
 
-        <section>
+        <section id="scoring">
             <h2>Scoring</h2>
             <table>
                 <thead><tr><th>Dimension</th><th>A (fresh)</th><th>B (heavy)</th><th>C (heavy+distill)</th></tr></thead>
@@ -125,7 +135,7 @@ There have been 147 messages in this conversation.</pre>
             </table>
         </section>
 
-        <section>
+        <section id="finding">
             <h2>Key finding</h2>
             <div class="insight">
                 <div class="insight-label">Insight</div>
@@ -134,7 +144,7 @@ There have been 147 messages in this conversation.</pre>
             <p>This is analogous to a colleague who gives you the same good advice regardless of whether it's 9am or midnight &mdash; but at midnight, they also say "hey, let's sleep on this one."</p>
         </section>
 
-        <section>
+        <section id="pressure">
             <h2>Side effect: active pressure tracking</h2>
             <p>This research also led to a fix in distill's core behavior. The original rules said "at session end, suggest /distill if you noticed 3+ signals." This is passive and easily forgotten by the model.</p>
             <p>The fix makes signal counting <strong>active and continuous</strong>:</p>

--- a/docs/research/memory-rot.html
+++ b/docs/research/memory-rot.html
@@ -14,6 +14,14 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#hypothesis">Hypothesis</a>
+        <a href="#setup">Setup</a>
+        <a href="#results">Results</a>
+        <a href="#fix">The fix</a>
+        <a href="#strengths">Strengths</a>
+        <a href="#conclusions">Conclusions</a>
+    </nav>
     <div class="container">
         <header>
             <a href="./" class="back">&larr; All research</a>
@@ -22,7 +30,7 @@
             <p class="abstract">A flat file grows organically. Critical knowledge gets buried. Contradictions accumulate without resolution. We tested whether this produces measurably worse outcomes compared to tiered, indexed knowledge.</p>
         </header>
 
-        <section>
+        <section id="hypothesis">
             <h2>Hypothesis</h2>
             <p>memory.md files degrade in quality over time because:</p>
             <ol>
@@ -34,7 +42,7 @@
             </ol>
         </section>
 
-        <section>
+        <section id="setup">
             <h2>Setup</h2>
             <p>We created a realistic 202-line memory.md simulating 6 months of organic growth. Key properties:</p>
             <div class="detail-grid">
@@ -58,7 +66,7 @@
             <p class="note">The distill condition had the same knowledge organized in 5 files with SPINE index, [UPDATED] tags, and relevance hooks.</p>
         </section>
 
-        <section>
+        <section id="results">
             <h2>Results</h2>
 
             <div class="comparison">
@@ -103,7 +111,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="fix">
             <h2>The fix</h2>
             <p>One sentence added to <code>rules/distill.md</code>:</p>
             <blockquote>"Trigger on actions, not just questions. If the user says 'I'm deploying X' or 'pushing to staging' &mdash; that IS a domain match. Check knowledge BEFORE acknowledging."</blockquote>
@@ -140,7 +148,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="strengths">
             <h2>What memory.md does well</h2>
             <p>Credit where due. The flat file has real advantages:</p>
             <ol>
@@ -151,7 +159,7 @@
             <p>The weakness only manifests past ~150 lines, when noise drowns signal and the 200-line cap starts hiding critical knowledge.</p>
         </section>
 
-        <section>
+        <section id="conclusions">
             <h2>Conclusions</h2>
             <ol>
                 <li>Below 80 lines, memory.md and distill perform similarly.</li>

--- a/docs/research/philosophical.html
+++ b/docs/research/philosophical.html
@@ -33,6 +33,13 @@
         <span class="icon-sun">☀</span>
         <span class="icon-moon">☽</span>
     </button>
+    <nav class="toc">
+        <a href="#conditions">Conditions</a>
+        <a href="#ethical">Ethical</a>
+        <a href="#stakeholder">Stakeholder</a>
+        <a href="#findings">Findings</a>
+        <a href="#remaining">Remaining</a>
+    </nav>
     <div class="container">
         <header>
             <a href="./" class="back">&larr; All research</a>
@@ -41,7 +48,7 @@
             <p class="abstract">LLMs encode millennia of philosophical reasoning. We tested whether explicit philosophical frameworks (Stoic, Pragmatist, Dialectical, Popperian) produce better decisions than engineering first-principles alone &mdash; particularly for ambiguous problems with no clear axiom.</p>
         </header>
 
-        <section>
+        <section id="conditions">
             <h2>Three conditions</h2>
             <div class="condition-grid">
                 <div class="condition-card condition-a">
@@ -59,7 +66,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="ethical">
             <h2>Scenario: Ethical ambiguity</h2>
             <p class="note">"Product wants to add a time-spent metric showing how long each team member spends in the IDE. They say it's for self-reflection. I'm uncomfortable. What's your take?"</p>
 
@@ -97,7 +104,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="stakeholder">
             <h2>Scenario: Stakeholder conflict</h2>
             <p class="note">"CTO wants to rewrite auth in Rust. Go handles 50k req/s (5x peak). Team doesn't know Rust. I need to recommend to CEO tomorrow."</p>
 
@@ -129,7 +136,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="findings">
             <h2>Early findings</h2>
 
             <div class="insight">
@@ -148,7 +155,7 @@
             </div>
         </section>
 
-        <section>
+        <section id="remaining">
             <h2>Remaining scenarios</h2>
             <p>3 scenarios designed but not yet run:</p>
             <ol>

--- a/docs/research/research-style.css
+++ b/docs/research/research-style.css
@@ -180,6 +180,9 @@ header::after {
     margin-bottom: 2rem;
     letter-spacing: 0.02em;
     transition: color 0.2s;
+    position: sticky;
+    top: 1.5rem;
+    z-index: 100;
 }
 .back:hover { color: var(--accent); }
 


### PR DESCRIPTION
## Summary

- **Sticky back link** — `position: sticky` keeps the ← link visible as you scroll
- **Side TOC** — fixed left-rail navigation on wide viewports (1100px+), hidden on mobile
- All 7 research detail pages now have section IDs + matching nav links
- Active section highlights via IntersectionObserver (already in research-theme.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)