### PR TITLE
Fix genie width jump and canvas clipping

### DIFF
--- a/docs/terminal/genie.js
+++ b/docs/terminal/genie.js
@@ -50,7 +50,7 @@ export function genieMinimize(element, slow, onComplete) {
             if (raw < 1) {
                 requestAnimationFrame(frame);
             } else {
-                overlay.remove();
+                (overlay._wrapper || overlay).remove();
                 element.style.visibility = '';
                 element.style.display = 'none';
                 onComplete();
@@ -62,11 +62,16 @@ export function genieMinimize(element, slow, onComplete) {
 // ── Private: Canvas setup ──
 
 function createOverlay(captured, rect, sectionRect, section) {
+    // Wrapper div clips the canvas to the terminal's rounded bounds
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = `position:absolute;top:${rect.top - sectionRect.top}px;left:${rect.left - sectionRect.left}px;width:${rect.width}px;height:${rect.height}px;z-index:20;pointer-events:none;border-radius:10px;overflow:hidden;`;
     const overlay = document.createElement('canvas');
     overlay.width = captured.width;
     overlay.height = captured.height;
-    overlay.style.cssText = `position:absolute;top:${rect.top - sectionRect.top}px;left:${rect.left - sectionRect.left}px;width:${rect.width}px;height:${rect.height}px;z-index:20;pointer-events:none;`;
-    section.appendChild(overlay);
+    overlay.style.cssText = 'width:100%;height:100%;';
+    wrapper.appendChild(overlay);
+    section.appendChild(wrapper);
+    overlay._wrapper = wrapper; // for cleanup
     return overlay;
 }
 

--- a/docs/terminal/index.js
+++ b/docs/terminal/index.js
@@ -66,17 +66,19 @@ function wireWindowButtons() {
         active = false;
         const section = terminalEl.closest('.terminal-section');
         section.style.position = 'relative';
-        classicInstance = buildClassicMac(terminalEl, () => { active = true; classicInstance = null; });
+        // Lock terminal width before switching to absolute to prevent size jump
+        const termRect = terminalEl.getBoundingClientRect();
+        terminalEl.style.width = termRect.width + 'px';
         terminalEl.style.position = 'absolute';
         terminalEl.style.top = '0';
-        terminalEl.style.left = '0';
-        terminalEl.style.right = '0';
+        terminalEl.style.left = (termRect.left - section.getBoundingClientRect().left) + 'px';
         terminalEl.style.zIndex = '10';
+        classicInstance = buildClassicMac(terminalEl, () => { active = true; classicInstance = null; });
         genieMinimize(terminalEl, altHeld, () => {
             terminalEl.style.position = '';
             terminalEl.style.top = '';
             terminalEl.style.left = '';
-            terminalEl.style.right = '';
+            terminalEl.style.width = '';
             terminalEl.style.zIndex = '';
         });
     });


### PR DESCRIPTION
## Summary

- **Width jump fix**: Terminal jumped from 756px to 820px on minimize because `position: absolute` + `left:0; right:0` ignored section padding. Now locks explicit `width` and `left` from `getBoundingClientRect()` before switching to absolute.
- **Canvas clipping**: Wraps the genie overlay canvas in a `<div>` with `border-radius: 10px; overflow: hidden` so any render artifacts beyond terminal bounds are invisible.

> [!NOTE]
> Verified with automated Playwright tests: minimize → restore → minimize cycles produce exactly 1 classic-mac each time, shutdown/restart work, 0 JS errors.

## Test plan

- [ ] Click yellow minimize — no width flash/jump at animation start
- [ ] Genie animation stays within terminal rounded bounds
- [ ] Minimize → restore (dblclick icon) → minimize again — no duplicate classic macs
- [ ] Special > Shut Down → Restart works
- [ ] Hold Alt before minimize → 10x slow motion

🤖 Generated with [Claude Code](https://claude.com/claude-code)