### PR TITLE
Kernel panic restart + TDZ fixes

### DIFF
--- a/docs/terminal/claude-easter-egg.js
+++ b/docs/terminal/claude-easter-egg.js
@@ -2,7 +2,7 @@
 // Typing "claude" in the shell launches a fake Claude Code session.
 // Any input triggers a comedic context overflow leading to a kernel panic screen.
 
-export function createClaudeEasterEgg({ body, addLine, showFooter, killCursors, removeFooter, footerType, footerCursor, terminalEl, setActive }) {
+export function createClaudeEasterEgg({ body, addLine, showFooter, killCursors, removeFooter, footerType, footerCursor, terminalEl, setActive, onPanicRestart }) {
     let inClaude = false, claudeReady = false;
 
     return { startClaude, handleClaudeInput, isInClaude: () => inClaude, isReady: () => claudeReady };
@@ -101,7 +101,7 @@ export function createClaudeEasterEgg({ body, addLine, showFooter, killCursors, 
         const lines = panicLines();
         let i = 0;
         (function go() {
-            if (i >= lines.length) return;
+            if (i >= lines.length) { showRestartPrompt(); return; }
             const l = document.createElement('div');
             l.className = 'term-line visible';
             l.innerHTML = lines[i] || '&nbsp;';
@@ -111,6 +111,31 @@ export function createClaudeEasterEgg({ body, addLine, showFooter, killCursors, 
             i++;
             setTimeout(go, i < 3 ? 100 : 40);
         })();
+    }
+
+    function showRestartPrompt() {
+        const el = document.createElement('div');
+        el.className = 'term-line visible';
+        el.style.fontSize = '0.68rem';
+        el.style.lineHeight = '1.6';
+        el.style.marginTop = '1rem';
+        el.innerHTML = '<span style="color:#565f89">Press any key to restart...</span><span class="term-cursor"></span>';
+        body.appendChild(el);
+        body.scrollTop = body.scrollHeight;
+
+        function onKey(e) {
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            e.preventDefault();
+            document.removeEventListener('keydown', onKey);
+            body.style.background = '';
+            body.style.padding = '';
+            body.style.overflow = '';
+            body.innerHTML = '';
+            inClaude = false;
+            claudeReady = false;
+            if (onPanicRestart) onPanicRestart();
+        }
+        document.addEventListener('keydown', onKey);
     }
 
     function panicLines() {

--- a/docs/terminal/index.js
+++ b/docs/terminal/index.js
@@ -27,7 +27,8 @@ function startInteractiveMode() {
 
     const claudeEgg = createClaudeEasterEgg({
         body, terminalEl, setActive,
-        ...helpers
+        ...helpers,
+        onPanicRestart: () => startInteractiveMode(),
     });
 
     const shell = createShell({

--- a/docs/terminal/shell.js
+++ b/docs/terminal/shell.js
@@ -3,8 +3,38 @@
 
 export function createShell({ body, addLine, killCursors, startClaude }) {
     let buf = '';
-    let cur = prompt();
 
+    // ── Data (before headline to avoid TDZ — const is not hoisted) ──
+
+    const cmds = {
+        ls: (a) => {
+            const fs = {
+                '~': ['projects', '.claude', 'Documents'],
+                '~/.claude': ['CLAUDE.md', 'distill', 'commands', 'rules'],
+                '~/.claude/distill': ['SPINE.md', 'craft', 'ops', 'profile'],
+            };
+            return (fs[a] || fs['~']).map(f => f.includes('.') ? f : `<span style="color:#7aa2f7">${f}/</span>`).join('  ');
+        },
+        pwd: () => '/Users/visitor/projects/backend',
+        whoami: () => 'visitor',
+        echo: (a) => a || '',
+        cat: (a) => {
+            if (a && a.includes('SPINE')) return '<span style="color:#565f89"># Distill Knowledge Index</span>\n- [Kafka patterns](craft/kafka-patterns.md)\n- [Code style](craft/code-style.md)\n- [Working style](profile/working-style.md)';
+            if (a && a.includes('.zshrc')) return '<span style="color:#565f89"># lol nice try</span>';
+            return `<span style="color:#f72585">cat: ${a || ''}: No such file</span>`;
+        },
+        clear: () => '__CLEAR__',
+        help: () => '<span style="color:#565f89">ls, pwd, cat, echo, clear, whoami, neofetch, sudo, vim, claude</span>',
+        sudo: () => '<span style="color:#f72585">visitor is not in the sudoers file. This incident will be reported.</span>',
+        vim: () => '<span style="color:#565f89">Why would you do that to yourself?</span>',
+        rm: (a) => (a && a.includes('-rf')) ? '<span style="color:#f72585">rm: nice try, but no.</span>' : '',
+        neofetch: () => '<span style="color:#bb9af7">  .---.  </span>visitor@distill\n<span style="color:#bb9af7"> / O O \\ </span>OS: macOS 15.4 | Memory: \u221E (distilled)',
+        exit: () => '<span style="color:#565f89">logout\n[Process completed]</span>',
+    };
+
+    // ── Headline ──
+
+    let cur = prompt();
     return { prompt, exec, getBuffer, setBuffer, getCurrentLine };
 
     // ── Public API ──
@@ -38,35 +68,7 @@ export function createShell({ body, addLine, killCursors, startClaude }) {
         cur = prompt();
     }
 
-    // ── Private: Command definitions ──
-
-    const cmds = {
-        ls: (a) => {
-            const fs = {
-                '~': ['projects', '.claude', 'Documents'],
-                '~/.claude': ['CLAUDE.md', 'distill', 'commands', 'rules'],
-                '~/.claude/distill': ['SPINE.md', 'craft', 'ops', 'profile'],
-            };
-            return (fs[a] || fs['~']).map(f => f.includes('.') ? f : `<span style="color:#7aa2f7">${f}/</span>`).join('  ');
-        },
-        pwd: () => '/Users/visitor/projects/backend',
-        whoami: () => 'visitor',
-        echo: (a) => a || '',
-        cat: (a) => {
-            if (a && a.includes('SPINE')) return '<span style="color:#565f89"># Distill Knowledge Index</span>\n- [Kafka patterns](craft/kafka-patterns.md)\n- [Code style](craft/code-style.md)\n- [Working style](profile/working-style.md)';
-            if (a && a.includes('.zshrc')) return '<span style="color:#565f89"># lol nice try</span>';
-            return `<span style="color:#f72585">cat: ${a || ''}: No such file</span>`;
-        },
-        clear: () => '__CLEAR__',
-        help: () => '<span style="color:#565f89">ls, pwd, cat, echo, clear, whoami, neofetch, sudo, vim, claude</span>',
-        sudo: () => '<span style="color:#f72585">visitor is not in the sudoers file. This incident will be reported.</span>',
-        vim: () => '<span style="color:#565f89">Why would you do that to yourself?</span>',
-        rm: (a) => (a && a.includes('-rf')) ? '<span style="color:#f72585">rm: nice try, but no.</span>' : '',
-        neofetch: () => '<span style="color:#bb9af7">  .---.  </span>visitor@distill\n<span style="color:#bb9af7"> / O O \\ </span>OS: macOS 15.4 | Memory: \u221E (distilled)',
-        exit: () => '<span style="color:#565f89">logout\n[Process completed]</span>',
-    };
-
-    // ── Private: Output rendering ──
+    // ── Private ──
 
     function appendOutput(html) {
         const el = document.createElement('div');


### PR DESCRIPTION
## Summary

- **Kernel panic recovery**: After the Mythos kernel panic sequence, shows "Press any key to restart..." with a blinking cursor. Any keypress clears the terminal and starts a fresh interactive shell.
- **shell.js TDZ fix**: `const cmds` was declared after `return`, causing a temporal dead zone error when `exec()` tried to access it. Moved data before the headline block.
- **Wiring**: `onPanicRestart` callback flows from easter egg → orchestrator → `startInteractiveMode()` for a clean restart.

> [!IMPORTANT]
> The TDZ pattern (`const` after `return`) is a recurring issue with the Primera Plana style in JS. Function declarations are hoisted, but `const`/`let` are not. All data must come before the headline block.

## Test plan (automated with Playwright)

- [x] `claude` → type anything → kernel panic → "Press any key" prompt
- [x] Press key → fresh shell with `$` prompt
- [x] `whoami` works after restart
- [x] Minimize works after panic restart (1 classic mac, no duplicates)
- [x] 0 JS errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)