### PR TITLE
Add independent PR review protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# aura-distill Development Guide
+
+## What this is
+
+A first-principles memory system for Claude Code. Users install it via `install.sh`, which places files into `~/.claude/distill/`. The `/distill` slash command triggers retrospective distillation of conversation signals into tiered knowledge files.
+
+## Architecture
+
+- `distill.md` — Dispatcher (runs in main context, harvests signals, spawns sub-agent)
+- `distill-process.md` — Sub-agent instructions (the full distillation pipeline)
+- `distill-monitor.md` — Session-start monitor (minimal, loaded via `rules/distill.md`)
+- `knowledge-architecture.md` — Tier system design doc
+- `install.sh` / `install.ps1` — User-facing installers
+- `tests/` — A/B test scenarios, cognitive bias tests, persona-based methodology tests
+- `docs/` — GitHub Pages site (landing, research)
+- `dashboard/` — Analytics dashboard
+
+## CRITICAL: Never touch real user data
+
+**NEVER read, write, or test against `~/.claude/` or `~/.claude-personal/` on this machine.**
+
+These directories contain the developer's real distilled knowledge. An errant write, backup, or test run against them risks data loss (this has already happened once — see the `_distill_isolation_bak` incident).
+
+When developing or testing:
+- Use test personas under `tests/scenarios/methodology/persona-sofia/` and `persona-marcus/`
+- Use the sandboxed test harness: `./test-with-claudia.sh` (creates a temp dir via `mktemp -d`)
+- For ad-hoc testing, create temp directories: `mktemp -d` or use `tests/scenarios/`
+- If you need to reference real distill structure for context, **read only** — never write
+
+## Version management
+
+- Current version is in `VERSION` file (semver)
+- `install.sh` has its own `VERSION` variable that must be kept in sync
+- Bump both when releasing
+
+## Key conventions
+
+- All distill files use `{DISTILL_DIR}` as a placeholder — `install.sh` resolves it to the actual path via `sed`
+- The SPINE (Tier 1) is the auto-loaded index — max 80 lines, pointers only
+- Tier 2 files are max 60 lines each, one topic per file
+- The `rules/distill.md` always-on section is capped at 15 lines of preferences
+
+## Testing
+
+- `tests/scenarios/methodology/` — A/B tests comparing WITH vs WITHOUT distill knowledge
+- `tests/scenarios/cognitive/` — Bias detection tests (anchoring, authority, recency, loss aversion)
+- `tests/scenarios/retrieval/` — Knowledge retrieval accuracy tests
+- `tests/scenarios/distillation/` — Full-loop distillation tests
+- Test personas: Sofia (senior backend engineer) and Marcus (product manager)
+- Run persona tests: `./tests/scenarios/methodology/run-persona-test.sh`
+- Run integration tests: `./test-with-claudia.sh`
+
+## PR reviews
+
+Every PR must be reviewed by an independent agent before merging. See `REVIEW-PROTOCOL.md`.
+
+The authoring agent spawns a reviewer in a worktree with zero shared context. The reviewer gets only product context — never the author's reasoning, known limitations, or focus suggestions. This is structural, not optional: shared context makes self-review biased by definition.
+
+## Branch conventions
+
+- `main` — stable, released (protected: PRs required, enforced on admins)
+- `feature/*` — in-progress work

--- a/REVIEW-PROTOCOL.md
+++ b/REVIEW-PROTOCOL.md
@@ -1,0 +1,140 @@
+# PR Review Protocol
+
+## Why this exists
+
+This project is fully LLM-coded. When the same agent writes code and reviews it, the review is structurally biased — the agent knows *why* every decision was made, so every decision looks justified. This isn't a reasoning failure. It's an inevitable property of shared context.
+
+**The fix is perspective, not effort.** A clean agent with zero knowledge of the authoring conversation evaluates code on its merits alone. It doesn't know what was "hard to get working" or what tradeoff was agonized over — so it can't give those decisions a pass.
+
+## Protocol
+
+Every PR must be reviewed by a **separate agent in a worktree** before merging. The reviewing agent:
+
+- Has **no access** to the conversation that produced the changes
+- Gets **only** the product context (what the project does, who it's for)
+- Must form its own understanding of the codebase by reading it
+- Reports issues it finds — not issues it was told to look for
+
+### How to invoke
+
+When a PR is ready for review, the authoring agent spawns:
+
+```
+Agent({
+  description: "Independent PR review",
+  isolation: "worktree",
+  prompt: <the review prompt below, filled in with the PR number>
+})
+```
+
+The authoring agent **must not** include:
+- Its own assessment of the changes
+- Reasoning behind decisions ("we did X because Y")
+- Known limitations or caveats ("the lock file approach is a workaround")
+- Suggestions for what the reviewer should focus on
+
+The authoring agent **may** include:
+- The PR number
+- The branch name
+- A one-line summary of the feature area (e.g., "concurrency changes to the distillation pipeline")
+
+Anything beyond that contaminates the review.
+
+---
+
+## Review prompt template
+
+Copy this prompt verbatim. Fill in only `{PR_NUMBER}`.
+
+```
+You are reviewing PR #{PR_NUMBER} on an open-source project you have never seen before.
+
+## Product context
+
+aura-distill is a first-principles memory system for Claude Code. Users install it via a shell script. It places markdown files into ~/.claude/distill/. A /distill slash command triggers retrospective distillation of conversation signals into tiered knowledge files. The system runs entirely inside Claude Code — no server, no dependencies, just markdown files and prompts.
+
+Target users: developers using Claude Code who want persistent, structured memory across sessions.
+
+## Your task
+
+Review this PR thoroughly. You are the only quality gate before this ships to users.
+
+### Step 0: Understand the project
+
+Read CLAUDE.md, README.md, and the key architecture files to understand the codebase. Do NOT skip this — you need project context to evaluate whether changes are correct and coherent.
+
+### Step 1: Understand the PR
+
+Run `gh pr view {PR_NUMBER}` and `gh pr diff {PR_NUMBER}`. Read every changed file in full (not just the diff) to understand the surrounding context.
+
+### Step 2: Evaluate
+
+For each area, report PASS, FLAG (concern but not blocking), or BLOCK (must fix before merge):
+
+**Correctness**
+- Do the changes do what they claim?
+- Are there logic errors, race conditions, or unhandled edge cases?
+- Do file references and paths resolve correctly?
+
+**Consistency**
+- Do changes in one file match changes in related files? (e.g., if the dispatcher references .status, does the process engine also reference .status?)
+- Are naming conventions consistent with the rest of the codebase?
+- Do version numbers match across VERSION, install.sh, and docs?
+
+**Security**
+- Could any change expose user data or grant unintended permissions?
+- Are there any paths where user input flows into shell commands unsanitized?
+- Does the install script do anything beyond what it claims?
+
+**Regression risk**
+- Could existing users be broken by this change?
+- Are there backwards-compatibility concerns (e.g., old .lock files vs new .status files)?
+- If a file format changed, is there migration handling?
+
+**Test coverage**
+- Are the changes tested? Run the test suite if one exists.
+- Are edge cases covered?
+- If tests were updated, do the new assertions match the new behavior?
+
+**Documentation**
+- Do user-facing docs (README, landing page, install output) match the new behavior?
+- Are internal docs (CLAUDE.md, architecture docs) updated?
+
+**Prompt quality** (specific to this project — the "code" is largely LLM prompts)
+- Are instructions to Claude clear and unambiguous?
+- Could Claude misinterpret any instruction in a way that causes harm?
+- Are there conflicting instructions between files?
+
+### Step 3: Report
+
+Structure your review as:
+
+#### Summary
+One paragraph: what this PR does and your overall assessment.
+
+#### Findings
+List each finding with its severity (PASS / FLAG / BLOCK), the file and line, and a clear explanation. Group by area.
+
+#### Verdict
+APPROVE, REQUEST CHANGES, or NEEDS DISCUSSION. With a one-line justification.
+```
+
+---
+
+## Rules
+
+1. **Never self-review in the same context.** If you wrote it, you cannot review it. Period.
+2. **The reviewer's verdict is respected.** If it says BLOCK, you fix the issue before merging. Don't argue with the reviewer in a different context window — fix the code.
+3. **Don't coach the reviewer.** The whole point is an unbiased perspective. If you tell it "pay special attention to the lock file migration," you've already biased it toward approving the migration and looking for small issues instead of questioning whether the approach is right.
+4. **Run tests in the worktree.** The reviewer should execute `./test-with-claudia.sh` or equivalent in its isolated copy. A review without running tests is incomplete.
+5. **One reviewer per PR.** Don't spawn multiple reviewers hoping one will approve. If the first reviewer blocks, fix the issues and request a new review.
+
+## What good looks like
+
+A good independent review catches things like:
+- "The dispatcher checks `.status` but the process engine still references `.lock` in one place" (consistency)
+- "The install script writes to `~/.claude/settings.json` but doesn't handle the case where settings.json is malformed JSON" (edge case)
+- "The FAQ says 'it complements memory.md' but the monitor explicitly tells Claude NOT to use memory.md" (contradiction)
+- "There's no migration path for users who have the old `.lock` file — their next distill will think a stale lock exists" (regression)
+
+These are exactly the things the authoring agent would miss — because it *knows* the lock migration is handled, and that knowledge prevents it from checking.

--- a/REVIEW-PROTOCOL.md
+++ b/REVIEW-PROTOCOL.md
@@ -61,7 +61,7 @@ Review this PR thoroughly. You are the only quality gate before this ships to us
 
 ### Step 0: Understand the project
 
-Read CLAUDE.md, README.md, and the key architecture files to understand the codebase. Do NOT skip this — you need project context to evaluate whether changes are correct and coherent.
+Read CLAUDE.md, README.md, and the architecture files listed in CLAUDE.md's Architecture section (distill.md, distill-process.md, distill-monitor.md, knowledge-architecture.md, install.sh). Do NOT skip this — you need project context to evaluate whether changes are correct and coherent.
 
 ### Step 1: Understand the PR
 
@@ -126,7 +126,7 @@ APPROVE, REQUEST CHANGES, or NEEDS DISCUSSION. With a one-line justification.
 1. **Never self-review in the same context.** If you wrote it, you cannot review it. Period.
 2. **The reviewer's verdict is respected.** If it says BLOCK, you fix the issue before merging. Don't argue with the reviewer in a different context window — fix the code.
 3. **Don't coach the reviewer.** The whole point is an unbiased perspective. If you tell it "pay special attention to the lock file migration," you've already biased it toward approving the migration and looking for small issues instead of questioning whether the approach is right.
-4. **Run tests in the worktree.** The reviewer should execute `./test-with-claudia.sh` or equivalent in its isolated copy. A review without running tests is incomplete.
+4. **Run tests in the worktree.** The reviewer should execute `./test-with-claudia.sh` or equivalent in its isolated copy. If the test harness is unavailable (e.g., missing auth config), note this in the review and evaluate test coverage from code inspection instead.
 5. **One reviewer per PR.** Don't spawn multiple reviewers hoping one will approve. If the first reviewer blocks, fix the issues and request a new review.
 
 ## What good looks like


### PR DESCRIPTION
## Summary

- Adds `REVIEW-PROTOCOL.md` — a structured protocol for independent PR reviews on LLM-coded projects
- Updates `CLAUDE.md` to reference the protocol and document main branch protection

## Why

This project is fully LLM-coded. When the same agent authors and reviews code, the review is structurally biased — shared context means the reviewer already knows *why* decisions were made. The protocol requires spawning a clean agent in a worktree with zero authoring context.

## Test plan

- [ ] Use the protocol to review this very PR (meta-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)