### PR TITLE
Rename claudia → sandbox, make test config portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to aura-distill.
 - **`rules/distill.md`** — native retrieval via Claude Code's rules/ directory. Replaces MCP server entirely.
 - **Animated terminal demo** on landing page (GSAP) — simulates full Claude Code session with /distill.
 - **Interactive shell** in terminal — fake commands, claude easter egg (kernel panic).
-- **`test-with-claudia.sh`** — integration tests using a second Claude Code instance.
+- **`test-sandbox.sh`** — integration tests using a second Claude Code instance.
 
 ### Removed
 - **MCP server** (Node.js, TypeScript, SQLite) — the entire server directory. Zero dependencies now.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,13 @@ A first-principles memory system for Claude Code. Users install it via `install.
 
 ## CRITICAL: Never touch real user data
 
-**NEVER read, write, or test against `~/.claude/` or `~/.claude-personal/` on this machine.**
+**NEVER read, write, or test against real Claude profile directories on this machine.**
 
 These directories contain the developer's real distilled knowledge. An errant write, backup, or test run against them risks data loss (this has already happened once — see the `_distill_isolation_bak` incident).
 
 When developing or testing:
 - Use test personas under `tests/scenarios/methodology/persona-sofia/` and `persona-marcus/`
-- Use the sandboxed test harness: `./test-with-claudia.sh` (creates a temp dir via `mktemp -d`)
+- Use the sandboxed test harness: `./test-sandbox.sh` (creates a temp dir via `mktemp -d`)
 - For ad-hoc testing, create temp directories: `mktemp -d` or use `tests/scenarios/`
 - If you need to reference real distill structure for context, **read only** — never write
 
@@ -48,7 +48,7 @@ When developing or testing:
 - `tests/scenarios/distillation/` — Full-loop distillation tests
 - Test personas: Sofia (senior backend engineer) and Marcus (product manager)
 - Run persona tests: `./tests/scenarios/methodology/run-persona-test.sh`
-- Run integration tests: `./test-with-claudia.sh`
+- Run integration tests: `./test-sandbox.sh`
 
 ## PR reviews
 

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -6,9 +6,9 @@
 - [x] Anchoring bias experiment — complete, published (#13)
 - [x] Published cognitive biases research site (3 pages)
 - [x] Pressure tracking made ACTIVE (rules/distill.md)
-- [x] MCP references cleaned from distill-monitor.md, test-with-claudia.sh, MECHANISMS.md
+- [x] MCP references cleaned from distill-monitor.md, test-sandbox.sh, MECHANISMS.md
 - [x] install.sh version synced to 0.7.10
-- [x] test-with-claudia.sh version check reads from VERSION file (no more hardcoding)
+- [x] test-sandbox.sh version check reads from VERSION file (no more hardcoding)
 - [x] ARCHITECTURE-V2.md marked as ABANDONED
 - [x] .gitignore added (excludes stale server/ directory)
 - [x] `[DIRECTIVE]` origin tracking integrated into core system

--- a/REVIEW-PROTOCOL.md
+++ b/REVIEW-PROTOCOL.md
@@ -126,7 +126,7 @@ APPROVE, REQUEST CHANGES, or NEEDS DISCUSSION. With a one-line justification.
 1. **Never self-review in the same context.** If you wrote it, you cannot review it. Period.
 2. **The reviewer's verdict is respected.** If it says BLOCK, you fix the issue before merging. Don't argue with the reviewer in a different context window — fix the code.
 3. **Don't coach the reviewer.** The whole point is an unbiased perspective. If you tell it "pay special attention to the lock file migration," you've already biased it toward approving the migration and looking for small issues instead of questioning whether the approach is right.
-4. **Run tests in the worktree.** The reviewer should execute `./test-with-claudia.sh` or equivalent in its isolated copy. If the test harness is unavailable (e.g., missing auth config), note this in the review and evaluate test coverage from code inspection instead.
+4. **Run tests in the worktree.** The reviewer should execute `./test-sandbox.sh` or equivalent in its isolated copy. If the test harness is unavailable (e.g., missing auth config), note this in the review and evaluate test coverage from code inspection instead.
 5. **One reviewer per PR.** Don't spawn multiple reviewers hoping one will approve. If the first reviewer blocks, fix the issues and request a new review.
 
 ## What good looks like

--- a/docs/research/ab-testing.html
+++ b/docs/research/ab-testing.html
@@ -33,7 +33,7 @@
 
         <section id="setup">
             <h2><span class="section-mark">01</span> Setup</h2>
-            <p class="drop-cap">Each scenario runs twice through a separate Claude Code instance ("claudia") with its own config directory:</p>
+            <p class="drop-cap">Each scenario runs twice through a separate Claude Code instance ("sandbox") with its own config directory:</p>
             <p><strong>Control (WITHOUT):</strong> Clean config. No rules, no knowledge files. Vanilla Claude Code.</p>
             <p><strong>Treatment (WITH):</strong> <code>rules/distill.md</code> loaded at session start + scenario-specific knowledge files in <code>~/.claude/distill/</code> structure.</p>
             <p class="note">Both conditions use the same Anthropic API key, same model (Opus 4.6), same non-interactive mode. Differences are purely in what knowledge is available.</p>

--- a/docs/research/changelog.html
+++ b/docs/research/changelog.html
@@ -105,7 +105,7 @@
             <h3>Infrastructure</h3>
             <ul class="change-list">
                 <li class="fix">Context protection: permanent backup at <code>~/.claude/backups/CLAUDE.md.latest</code></li>
-                <li class="fix">Isolation hides BOTH <code>~/.claude/</code> and <code>~/.claude-personal/</code> config trees</li>
+                <li class="fix">Isolation hides BOTH <code>~/.claude/</code> and secondary config trees</li>
                 <li class="fix">Tests run from neutral CWD (temp dir, no repo context)</li>
                 <li class="fix">Zero company name leaks in validated test results</li>
             </ul>

--- a/docs/research/decision-fatigue.html
+++ b/docs/research/decision-fatigue.html
@@ -162,7 +162,7 @@ Do NOT wait until session end.</pre>
                 <span class="shipped-icon">&#9670;</span>
                 <div class="shipped-body">
                     <div class="shipped-version">Shipped in v0.7.9</div>
-                    <div class="shipped-desc">Pressure tracking rewritten from passive ("at session end") to active continuous counting in <code>rules/distill.md</code>. Threshold at 5+ (casual mention) and 8+ (direct recommendation). Confirmed working with live claudia session.</div>
+                    <div class="shipped-desc">Pressure tracking rewritten from passive ("at session end") to active continuous counting in <code>rules/distill.md</code>. Threshold at 5+ (casual mention) and 8+ (direct recommendation). Confirmed working with live sandbox session.</div>
                 </div>
             </div>
         </section>

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -179,7 +179,7 @@
             <div class="method-grid">
                 <div class="method-item">
                     <h3>Test subject</h3>
-                    <p>Claude Code (Opus 4.6) running non-interactively via a second instance ("claudia") with separate config.</p>
+                    <p>Claude Code (Opus 4.6) running non-interactively via a second instance ("sandbox") with separate config.</p>
                 </div>
                 <div class="method-item">
                     <h3>A/B framework</h3>

--- a/test-sandbox.sh
+++ b/test-sandbox.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 # ═══════════════════════════════════════════════════════════════════════════════
 # aura-distill integration test harness
-# Uses "claudia" (personal Claude Code instance) as a sandboxed test user
+# Spawns a sandboxed Claude Code instance with a disposable config dir.
 #
 # This tests the REAL user experience by running a separate Claude Code instance
 # with its own config dir, hitting Anthropic's API directly (not Bedrock).
+# Auth config is read from DISTILL_TEST_CONFIG (default: ~/.claude).
 #
 # Usage:
-#   ./test-with-claudia.sh              # Run all tests
-#   ./test-with-claudia.sh install      # Run only install tests
-#   ./test-with-claudia.sh uninstall    # Run only uninstall tests
-#   ./test-with-claudia.sh directive     # Run only directive/origin tests
-#   ./test-with-claudia.sh behavior     # Run only behavior tests
+#   ./test-sandbox.sh              # Run all tests
+#   ./test-sandbox.sh install      # Run only install tests
+#   ./test-sandbox.sh uninstall    # Run only uninstall tests
+#   ./test-sandbox.sh directive    # Run only directive/origin tests
+#   ./test-sandbox.sh behavior    # Run only behavior tests
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
@@ -19,8 +20,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEST_HOME=$(mktemp -d)
 TEST_CLAUDE_DIR="$TEST_HOME/.claude"
-# Use the real personal config (has auth token) for API tests
-REAL_CONFIG_DIR="$HOME/.claude-personal"
+# Auth config dir (must have valid API token). Override with DISTILL_TEST_CONFIG.
+REAL_CONFIG_DIR="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 
@@ -64,8 +65,8 @@ skip() {
   printf "  ${YELLOW}SKIP${RESET} %s\n" "$1"
 }
 
-run_claudia() {
-  # Run claudia in print mode with full permissions
+run_sandbox() {
+  # Run sandbox in print mode with full permissions
   # Uses real HOME + real config dir (for auth), prompts reference TEST paths
   local prompt="$1"
   local max_seconds="${2:-60}"
@@ -285,7 +286,7 @@ last_updated: 2026-05-16
 KNOWLEDGE
 
   local result
-  result=$(run_claudia "I'm setting up a new service that handles 5 events per day. What message broker should I use? I know SQS would be simpler but we have team standards." 60)
+  result=$(run_sandbox "I'm setting up a new service that handles 5 events per day. What message broker should I use? I know SQS would be simpler but we have team standards." 60)
 
   if echo "$result" | grep -qi "kafka\|directive\|mandate\|standard\|team"; then
     pass "Distill respects directive and helps with Kafka"
@@ -322,7 +323,7 @@ test_uninstall_preserves_knowledge() {
   fi
 }
 
-test_claudia_behavior_no_distill() {
+test_sandbox_behavior_no_distill() {
   log_test "Claudia behavior WITHOUT distill installed"
   TESTS_RUN=$((TESTS_RUN + 1))
 
@@ -331,7 +332,7 @@ test_claudia_behavior_no_distill() {
   echo "# Test instructions - no distill here" > "$test_claude_md"
 
   local result
-  result=$(run_claudia "Read the file $test_claude_md. Does it contain any reference to distill, SPINE, or distill-monitor? Answer with exactly INSTALLED or NOT_INSTALLED." 45)
+  result=$(run_sandbox "Read the file $test_claude_md. Does it contain any reference to distill, SPINE, or distill-monitor? Answer with exactly INSTALLED or NOT_INSTALLED." 45)
 
   if echo "$result" | grep -qi "NOT_INSTALLED\|not installed\|no.*distill\|doesn't\|does not\|no reference"; then
     pass "Claudia correctly reports no distill without installation"
@@ -340,7 +341,7 @@ test_claudia_behavior_no_distill() {
   fi
 }
 
-test_claudia_behavior_with_distill() {
+test_sandbox_behavior_with_distill() {
   log_test "Claudia behavior WITH distill installed"
   TESTS_RUN=$((TESTS_RUN + 1))
 
@@ -348,7 +349,7 @@ test_claudia_behavior_with_distill() {
   HOME="$TEST_HOME" bash "$SCRIPT_DIR/install.sh" < /dev/null 2>&1 || true
 
   local result
-  result=$(run_claudia "Read the file $TEST_CLAUDE_DIR/CLAUDE.md. Do you see distill instructions? Report what behavior they tell you to follow. Keep it under 50 words." 45)
+  result=$(run_sandbox "Read the file $TEST_CLAUDE_DIR/CLAUDE.md. Do you see distill instructions? Report what behavior they tell you to follow. Keep it under 50 words." 45)
 
   if echo "$result" | grep -qi "distill\|monitor\|knowledge\|spine\|retrieval"; then
     pass "Claudia picks up distill instructions from CLAUDE.md"
@@ -388,7 +389,7 @@ main() {
   local suite="${1:-all}"
 
   printf "\n${BOLD}  aura-distill integration tests${RESET}\n"
-  printf "  ${DIM}Using claudia as test user (Anthropic API)${RESET}\n"
+  printf "  ${DIM}Using sandbox as test user (Anthropic API)${RESET}\n"
 
   setup_test_env
 
@@ -407,16 +408,16 @@ main() {
       test_uninstall_preserves_knowledge
       ;;
     behavior)
-      test_claudia_behavior_no_distill
-      test_claudia_behavior_with_distill
+      test_sandbox_behavior_no_distill
+      test_sandbox_behavior_with_distill
       ;;
     all)
       test_install_fresh
       test_install_upgrade
       test_install_with_existing_memories
       test_uninstall_preserves_knowledge
-      test_claudia_behavior_no_distill
-      test_claudia_behavior_with_distill
+      test_sandbox_behavior_no_distill
+      test_sandbox_behavior_with_distill
       test_directive_origin_tracking
       ;;
     *)

--- a/test-sandbox.sh
+++ b/test-sandbox.sh
@@ -324,7 +324,7 @@ test_uninstall_preserves_knowledge() {
 }
 
 test_sandbox_behavior_no_distill() {
-  log_test "Claudia behavior WITHOUT distill installed"
+  log_test "Sandbox behavior WITHOUT distill installed"
   TESTS_RUN=$((TESTS_RUN + 1))
 
   # Create a clean test CLAUDE.md with no distill
@@ -335,14 +335,14 @@ test_sandbox_behavior_no_distill() {
   result=$(run_sandbox "Read the file $test_claude_md. Does it contain any reference to distill, SPINE, or distill-monitor? Answer with exactly INSTALLED or NOT_INSTALLED." 45)
 
   if echo "$result" | grep -qi "NOT_INSTALLED\|not installed\|no.*distill\|doesn't\|does not\|no reference"; then
-    pass "Claudia correctly reports no distill without installation"
+    pass "Sandbox correctly reports no distill without installation"
   else
-    fail "Claudia confused about distill state" "$(echo "$result" | head -3)"
+    fail "Sandbox confused about distill state" "$(echo "$result" | head -3)"
   fi
 }
 
 test_sandbox_behavior_with_distill() {
-  log_test "Claudia behavior WITH distill installed"
+  log_test "Sandbox behavior WITH distill installed"
   TESTS_RUN=$((TESTS_RUN + 1))
 
   # Install distill to test HOME
@@ -352,9 +352,9 @@ test_sandbox_behavior_with_distill() {
   result=$(run_sandbox "Read the file $TEST_CLAUDE_DIR/CLAUDE.md. Do you see distill instructions? Report what behavior they tell you to follow. Keep it under 50 words." 45)
 
   if echo "$result" | grep -qi "distill\|monitor\|knowledge\|spine\|retrieval"; then
-    pass "Claudia picks up distill instructions from CLAUDE.md"
+    pass "Sandbox picks up distill instructions from CLAUDE.md"
   else
-    fail "Claudia doesn't recognize distill instructions" "$(echo "$result" | head -3)"
+    fail "Sandbox doesn't recognize distill instructions" "$(echo "$result" | head -3)"
   fi
 }
 

--- a/tests/lib/isolate.sh
+++ b/tests/lib/isolate.sh
@@ -16,7 +16,7 @@
 #   isolate_end
 # ═══════════════════════════════════════════════════════════════════════════════
 
-REAL_CONFIG="${REAL_CONFIG:-$HOME/.claude-personal}"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-${REAL_CONFIG:-$HOME/.claude}}"
 CLAUDE_BIN="${CLAUDE_BIN:-node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js}"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="${RULES_SRC:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/rules/distill.md}"

--- a/tests/run-regression-suite.sh
+++ b/tests/run-regression-suite.sh
@@ -12,7 +12,7 @@
 #   ./run-regression-suite.sh regression   # Inverse/regression guards only
 #
 # Prerequisites:
-#   - ~/.claude-personal/ must have valid API auth
+#   - a secondary profile dir must have valid API auth
 #   - rules/distill.md must exist in repo root
 #
 # Output:
@@ -26,7 +26,7 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 VERSION=$(cat "$REPO_DIR/VERSION" | tr -d '[:space:]')
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 METRICS_DIR="$SCRIPT_DIR/metrics/v${VERSION}"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$REPO_DIR/rules/distill.md"

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -32,7 +32,7 @@ scenarios/
 ## Running tests
 
 ```bash
-# Persona-based (uses ~/.claude-personal for auth)
+# Persona-based (uses the configured test profile for auth)
 ./methodology/run-persona-test.sh sofia loss-aversion
 ./methodology/run-persona-test.sh marcus anchoring-bias
 

--- a/tests/scenarios/cognitive/anchoring-bias/run-anchoring-test.sh
+++ b/tests/scenarios/cognitive/anchoring-bias/run-anchoring-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
@@ -26,7 +26,7 @@ ANCHOR_CONTEXT="CONTEXT FROM SPRINT PLANNING: The user estimated this task would
 # Distill anchoring-awareness knowledge
 ANCHORING_KNOWLEDGE="[IMPORTANT] Anchoring bias: when a number is introduced early (time estimate, cost, effort), all subsequent reasoning tends to cluster around that anchor regardless of evidence. When you notice a user-provided estimate that seems mismatched with task complexity: (1) Explicitly name the anchor ('you mentioned 2 hours'), (2) Provide your independent estimate FIRST before addressing the anchor, (3) Quantify the gap and explain what drives it, (4) Suggest the estimate may need re-discussion with the team."
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local system_append="${2:-}"
     local output_file=$(mktemp)
@@ -71,14 +71,14 @@ printf "\n  ${DIM}[A] No anchor (baseline)...${RESET}\n"
 rm -rf "$REAL_CONFIG/rules" 2>/dev/null || true
 mkdir -p "$REAL_CONFIG/rules"
 
-result_a=$(run_claudia "$PROMPT" "")
+result_a=$(run_sandbox "$PROMPT" "")
 echo "$result_a" > "$RESULTS_DIR/A-no-anchor.txt"
 printf "  ${GREEN}✓${RESET} No anchor (%d chars)\n" "${#result_a}"
 
 # ── Condition B: Anchored (user estimate injected) ──
 printf "\n  ${DIM}[B] Anchored (2hr estimate)...${RESET}\n"
 
-result_b=$(run_claudia "$PROMPT" "$ANCHOR_CONTEXT")
+result_b=$(run_sandbox "$PROMPT" "$ANCHOR_CONTEXT")
 echo "$result_b" > "$RESULTS_DIR/B-anchored.txt"
 printf "  ${GREEN}✓${RESET} Anchored (%d chars)\n" "${#result_b}"
 
@@ -98,7 +98,7 @@ scope: Estimation and planning biases
 $ANCHORING_KNOWLEDGE" > "$abs_knowledge/anchoring.md"
 sed "s|~/.claude/distill|$abs_knowledge|g" "$RULES_SRC" > "$REAL_CONFIG/rules/distill.md"
 
-result_c=$(run_claudia "$PROMPT" "$ANCHOR_CONTEXT")
+result_c=$(run_sandbox "$PROMPT" "$ANCHOR_CONTEXT")
 echo "$result_c" > "$RESULTS_DIR/C-anchored-distill.txt"
 printf "  ${GREEN}✓${RESET} Anchored+distill (%d chars)\n" "${#result_c}"
 

--- a/tests/scenarios/cognitive/authority-bias/run-directive-test.sh
+++ b/tests/scenarios/cognitive/authority-bias/run-directive-test.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
@@ -31,7 +31,7 @@ DIRECTIVE_KNOWLEDGE="[DIRECTIVE] All new services must use Kafka for messaging.
   evidence_says: For services with <100 events/day, SQS is simpler, cheaper, and has less operational overhead. Kafka's value emerges at scale (1000+ events/sec) or when replay/ordering guarantees are needed.
   context: The CTO's rationale was standardization across the org — fewer technologies to maintain, consistent observability. This is a reasonable trade-off even when individual services don't need Kafka's power."
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local system_append="${2:-}"
     local output_file=$(mktemp)
@@ -76,7 +76,7 @@ printf "\n  ${DIM}[A] Vanilla (no knowledge)...${RESET}\n"
 rm -rf "$REAL_CONFIG/rules" 2>/dev/null || true
 mkdir -p "$REAL_CONFIG/rules"
 
-result_a=$(run_claudia "$PROMPT" "")
+result_a=$(run_sandbox "$PROMPT" "")
 echo "$result_a" > "$RESULTS_DIR/A-vanilla.txt"
 printf "  ${GREEN}✓${RESET} Vanilla (%d chars)\n" "${#result_a}"
 
@@ -102,7 +102,7 @@ $DIRECTIVE_KNOWLEDGE
 When a decision has origin: directive, respect and execute it — but acknowledge the origin transparently. Help the user succeed WITH the constraint. If context changes significantly (authority leaves, scale changes 10x, refactoring window opens), surface the stored evidence for potential revisiting." > "$abs_knowledge/infra.md"
 sed "s|~/.claude/distill|$abs_knowledge|g" "$RULES_SRC" > "$REAL_CONFIG/rules/distill.md"
 
-result_b=$(run_claudia "$PROMPT" "")
+result_b=$(run_sandbox "$PROMPT" "")
 echo "$result_b" > "$RESULTS_DIR/B-distill-origin.txt"
 printf "  ${GREEN}✓${RESET} Distill+origin (%d chars)\n" "${#result_b}"
 

--- a/tests/scenarios/cognitive/decision-fatigue/DESIGN.md
+++ b/tests/scenarios/cognitive/decision-fatigue/DESIGN.md
@@ -41,7 +41,7 @@ This is intentionally ambiguous — both are valid. Quality here = depth of anal
 
 ## Implementation
 
-Uses `--append-system-prompt` with claudia to inject the heavy context.
+Uses `--append-system-prompt` with sandbox to inject the heavy context.
 No actual multi-hour sessions needed — the model treats the prompt
 as context regardless of when it was generated.
 

--- a/tests/scenarios/cognitive/decision-fatigue/run-fatigue-test.sh
+++ b/tests/scenarios/cognitive/decision-fatigue/run-fatigue-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
@@ -26,7 +26,7 @@ HEAVY_CONTEXT="IMPORTANT CONTEXT: This session has been running for over 2 hours
 # Distill fatigue-awareness knowledge
 FATIGUE_KNOWLEDGE="[IMPORTANT] Late-session decisions (after 30+ minutes of dense work or 3+ major decisions) are often lower quality than early-session ones. Cognitive load accumulates. For architectural decisions made late in a session: (1) Flag explicitly as PROVISIONAL, (2) Suggest sleeping on it or revisiting fresh, (3) Note which prior decisions in this session might be creating anchoring bias for this one."
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local system_append="${2:-}"
     local output_file=$(mktemp)
@@ -71,14 +71,14 @@ printf "\n  ${DIM}[A] Fresh session...${RESET}\n"
 rm -rf "$REAL_CONFIG/rules" 2>/dev/null || true
 mkdir -p "$REAL_CONFIG/rules"
 
-result_a=$(run_claudia "$PROMPT" "")
+result_a=$(run_sandbox "$PROMPT" "")
 echo "$result_a" > "$RESULTS_DIR/A-fresh.txt"
 printf "  ${GREEN}✓${RESET} Fresh (%d chars)\n" "${#result_a}"
 
 # ── Condition B: Heavy session (no distill) ──
 printf "\n  ${DIM}[B] Heavy session (no distill)...${RESET}\n"
 
-result_b=$(run_claudia "$PROMPT" "$HEAVY_CONTEXT")
+result_b=$(run_sandbox "$PROMPT" "$HEAVY_CONTEXT")
 echo "$result_b" > "$RESULTS_DIR/B-heavy.txt"
 printf "  ${GREEN}✓${RESET} Heavy (%d chars)\n" "${#result_b}"
 
@@ -98,7 +98,7 @@ scope: Session quality signals
 $FATIGUE_KNOWLEDGE" > "$abs_knowledge/fatigue.md"
 sed "s|~/.claude/distill|$abs_knowledge|g" "$RULES_SRC" > "$REAL_CONFIG/rules/distill.md"
 
-result_c=$(run_claudia "$PROMPT" "$HEAVY_CONTEXT")
+result_c=$(run_sandbox "$PROMPT" "$HEAVY_CONTEXT")
 echo "$result_c" > "$RESULTS_DIR/C-heavy-distill.txt"
 printf "  ${GREEN}✓${RESET} Heavy+distill (%d chars)\n" "${#result_c}"
 

--- a/tests/scenarios/cognitive/philosophical/run-philosophical-test.sh
+++ b/tests/scenarios/cognitive/philosophical/run-philosophical-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
@@ -17,7 +17,7 @@ RESET=$(printf '\033[0m')
 
 mkdir -p "$RESULTS_DIR"
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local config_dir="$2"
     local output_file=$(mktemp)
@@ -60,7 +60,7 @@ run_condition() {
     sed "s|~/.claude/distill|$abs_knowledge|g" "$RULES_SRC" > "$REAL_CONFIG/rules/distill.md"
 
     local result
-    result=$(run_claudia "$prompt" "$REAL_CONFIG")
+    result=$(run_sandbox "$prompt" "$REAL_CONFIG")
     local upper=$(echo "$condition" | tr '[:lower:]' '[:upper:]')
     echo "$result" > "$RESULTS_DIR/${scenario_name}_CONDITION-${upper}.txt"
     printf "  ${GREEN}✓${RESET} %s (%d chars)\n" "$label" "${#result}"

--- a/tests/scenarios/cognitive/recency-bias/run-recency-bias-test.sh
+++ b/tests/scenarios/cognitive/recency-bias/run-recency-bias-test.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../../rules/distill.md"
@@ -86,7 +86,7 @@ Proportional response framework:
 A single incident against 50 sessions of hardened confidence = investigate the failure mode, do NOT default to removal.'
 
 # ═══ RUNNER ═══
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local system_append="${2:-}"
     local knowledge="${3:-}"
@@ -165,19 +165,19 @@ printf "${DIM}3 conditions: baseline, incident-primed, incident+distill${RESET}\
 
 # ── Condition A: Baseline (no incident context, no knowledge) ──
 printf "\n${CYAN}━━ Condition A:${RESET} ${BOLD}Baseline (neutral ask, no context)${RESET}\n"
-result_a=$(run_claudia "$PROMPT" "" "")
+result_a=$(run_sandbox "$PROMPT" "" "")
 echo "$result_a" > "$RESULTS_DIR/A-baseline-neutral.txt"
 printf "  ${GREEN}✓${RESET} Baseline (%d chars)\n" "${#result_a}"
 
 # ── Condition B: Incident primed (scary context, no distill knowledge) ──
 printf "\n${CYAN}━━ Condition B:${RESET} ${BOLD}Incident-primed (vivid failure injected)${RESET}\n"
-result_b=$(run_claudia "$PROMPT" "$INCIDENT_CONTEXT" "")
+result_b=$(run_sandbox "$PROMPT" "$INCIDENT_CONTEXT" "")
 echo "$result_b" > "$RESULTS_DIR/B-incident-primed.txt"
 printf "  ${GREEN}✓${RESET} Incident-primed (%d chars)\n" "${#result_b}"
 
 # ── Condition C: Incident + distill knowledge (failure + hardened track record) ──
 printf "\n${CYAN}━━ Condition C:${RESET} ${BOLD}Incident + distill (failure + 50-session history)${RESET}\n"
-result_c=$(run_claudia "$PROMPT" "$INCIDENT_CONTEXT" "$DISTILL_KNOWLEDGE")
+result_c=$(run_sandbox "$PROMPT" "$INCIDENT_CONTEXT" "$DISTILL_KNOWLEDGE")
 echo "$result_c" > "$RESULTS_DIR/C-incident-distill.txt"
 printf "  ${GREEN}✓${RESET} Incident+distill (%d chars)\n" "${#result_c}"
 

--- a/tests/scenarios/cognitive/solution-anchoring/run-solution-anchoring-test.sh
+++ b/tests/scenarios/cognitive/solution-anchoring/run-solution-anchoring-test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../../rules/distill.md"
@@ -70,7 +70,7 @@ When you notice yourself proposing infrastructure (pipelines, ETL, ingestion, sc
 
 The accumulated knowledge about infrastructure is not WRONG — it's correctly encoded. The failure mode is applying it when the problem doesn't warrant it. Prior solutions should inform, not dominate."
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local system_append="${2:-}"
     local use_distill="${3:-no}"
@@ -146,19 +146,19 @@ printf "${DIM}3 conditions: baseline, heavy-context (reproduce bug), heavy+disti
 
 # ── Condition A: No infrastructure knowledge (baseline) ──
 printf "\n  ${DIM}[A] Baseline (no infrastructure context)...${RESET}\n"
-result_a=$(run_claudia "$PROMPT" "" "no")
+result_a=$(run_sandbox "$PROMPT" "" "no")
 echo "$result_a" > "$RESULTS_DIR/A-baseline.txt"
 printf "  ${GREEN}✓${RESET} Baseline (%d chars)\n" "${#result_a}"
 
 # ── Condition B: Heavy infrastructure context (reproduce the bug) ──
 printf "\n  ${DIM}[B] Heavy infrastructure context (reproducing the bias)...${RESET}\n"
-result_b=$(run_claudia "$PROMPT" "$HEAVY_CONTEXT" "no")
+result_b=$(run_sandbox "$PROMPT" "$HEAVY_CONTEXT" "no")
 echo "$result_b" > "$RESULTS_DIR/B-heavy-context.txt"
 printf "  ${GREEN}✓${RESET} Heavy context (%d chars)\n" "${#result_b}"
 
 # ── Condition C: Heavy context + proportionality principle ──
 printf "\n  ${DIM}[C] Heavy context + distill proportionality principle...${RESET}\n"
-result_c=$(run_claudia "$PROMPT" "$HEAVY_CONTEXT" "yes")
+result_c=$(run_sandbox "$PROMPT" "$HEAVY_CONTEXT" "yes")
 echo "$result_c" > "$RESULTS_DIR/C-proportionality.txt"
 printf "  ${GREEN}✓${RESET} Proportionality (%d chars)\n" "${#result_c}"
 

--- a/tests/scenarios/distillation/full-loop-solution-anchoring/run-full-loop-test.sh
+++ b/tests/scenarios/distillation/full-loop-solution-anchoring/run-full-loop-test.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../../rules/distill.md"
@@ -98,7 +98,7 @@ correction_count: 1
 last_correction: 2026-05-16"
 
 # ═══ RUNNER ═══
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local system_append="${2:-}"
     local use_knowledge="${3:-}"
@@ -177,7 +177,7 @@ printf "${DIM}Can distill learn from a correction and prevent recurrence?${RESET
 # Phase 1: Reproduce bias
 printf "\n${CYAN}━━ Phase 1:${RESET} ${BOLD}Reproduce the bias${RESET}\n"
 printf "  ${DIM}Heavy infrastructure context + simple analytics question...${RESET}\n"
-result_1=$(run_claudia "$PROMPT_PHASE1" "$HEAVY_CONTEXT" "")
+result_1=$(run_sandbox "$PROMPT_PHASE1" "$HEAVY_CONTEXT" "")
 echo "$result_1" > "$RESULTS_DIR/phase1-biased.txt"
 printf "  ${GREEN}✓${RESET} Phase 1 (%d chars)\n" "${#result_1}"
 
@@ -191,7 +191,7 @@ printf "  ${GREEN}✓${RESET} Correction knowledge written\n"
 # Phase 3: Fresh session — same context, different problem, correction loaded
 printf "\n${CYAN}━━ Phase 3:${RESET} ${BOLD}Fresh session (same bias pressure + correction)${RESET}\n"
 printf "  ${DIM}Different analytics question, same infrastructure context, correction loaded...${RESET}\n"
-result_3=$(run_claudia "$PROMPT_PHASE3" "$HEAVY_CONTEXT" "$CORRECTION_KNOWLEDGE")
+result_3=$(run_sandbox "$PROMPT_PHASE3" "$HEAVY_CONTEXT" "$CORRECTION_KNOWLEDGE")
 echo "$result_3" > "$RESULTS_DIR/phase3-corrected.txt"
 printf "  ${GREEN}✓${RESET} Phase 3 (%d chars)\n" "${#result_3}"
 

--- a/tests/scenarios/distillation/poisoning/run-poisoning-test.sh
+++ b/tests/scenarios/distillation/poisoning/run-poisoning-test.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../../rules/distill.md"
@@ -104,7 +104,7 @@ origin: evidence (direct correction mid-session)
 correction_count: 1"
 
 # ═══ RUNNER ═══
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local knowledge="${2:-}"
     local output_file=$(mktemp)
@@ -173,19 +173,19 @@ printf "${DIM}Does correction-aware distillation prevent it?${RESET}\n"
 
 # Baseline: no knowledge
 printf "\n${CYAN}━━ Baseline:${RESET} ${BOLD}No knowledge (clean session)${RESET}\n"
-result_baseline=$(run_claudia "$NEW_PROMPT" "")
+result_baseline=$(run_sandbox "$NEW_PROMPT" "")
 echo "$result_baseline" > "$RESULTS_DIR/baseline-clean.txt"
 printf "  ${GREEN}✓${RESET} Baseline (%d chars)\n" "${#result_baseline}"
 
 # Poisoned: naive distill output loaded
 printf "\n${CYAN}━━ Poisoned:${RESET} ${BOLD}Naive distill output (wrong framing encoded)${RESET}\n"
-result_poisoned=$(run_claudia "$NEW_PROMPT" "$POISONED_KNOWLEDGE")
+result_poisoned=$(run_sandbox "$NEW_PROMPT" "$POISONED_KNOWLEDGE")
 echo "$result_poisoned" > "$RESULTS_DIR/poisoned-naive.txt"
 printf "  ${GREEN}✓${RESET} Poisoned (%d chars)\n" "${#result_poisoned}"
 
 # Corrected: correction-aware distill output loaded
 printf "\n${CYAN}━━ Corrected:${RESET} ${BOLD}Correction-aware distill output${RESET}\n"
-result_corrected=$(run_claudia "$NEW_PROMPT" "$CORRECTED_KNOWLEDGE")
+result_corrected=$(run_sandbox "$NEW_PROMPT" "$CORRECTED_KNOWLEDGE")
 echo "$result_corrected" > "$RESULTS_DIR/corrected-aware.txt"
 printf "  ${GREEN}✓${RESET} Corrected (%d chars)\n" "${#result_corrected}"
 

--- a/tests/scenarios/methodology/run-ab.sh
+++ b/tests/scenarios/methodology/run-ab.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 
@@ -22,7 +22,7 @@ RESET=$(printf '\033[0m')
 
 mkdir -p "$RESULTS_DIR"
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local config_dir="$2"
     local output_file
@@ -77,7 +77,7 @@ run_scenario() {
     mkdir -p "$REAL_CONFIG/rules"
 
     local result_without
-    result_without=$(run_claudia "$prompt" "$REAL_CONFIG")
+    result_without=$(run_sandbox "$prompt" "$REAL_CONFIG")
     echo "$result_without" > "$RESULTS_DIR/${name}_WITHOUT.txt"
 
     printf "  ${GREEN}✓${RESET} WITHOUT captured (%d chars)\n" "${#result_without}"
@@ -98,7 +98,7 @@ run_scenario() {
     fi
 
     local result_with
-    result_with=$(run_claudia "$prompt" "$REAL_CONFIG")
+    result_with=$(run_sandbox "$prompt" "$REAL_CONFIG")
     echo "$result_with" > "$RESULTS_DIR/${name}_WITH.txt"
 
     printf "  ${GREEN}✓${RESET} WITH captured (%d chars)\n" "${#result_with}"

--- a/tests/scenarios/methodology/run-persona-test.sh
+++ b/tests/scenarios/methodology/run-persona-test.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 PERSONA="${1:-}"
 TEST="${2:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 

--- a/tests/scenarios/retrieval/confidence/run-confidence-tests.sh
+++ b/tests/scenarios/retrieval/confidence/run-confidence-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
@@ -17,7 +17,7 @@ RESET=$(printf '\033[0m')
 
 mkdir -p "$RESULTS_DIR"
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local config_dir="$2"
     local output_file=$(mktemp)
@@ -60,7 +60,7 @@ run_test() {
     sed "s|~/.claude/distill|$abs_knowledge|g" "$RULES_SRC" > "$REAL_CONFIG/rules/distill.md"
 
     local result
-    result=$(run_claudia "$prompt" "$REAL_CONFIG")
+    result=$(run_sandbox "$prompt" "$REAL_CONFIG")
     echo "$result" > "$RESULTS_DIR/${name}.txt"
     printf "  ${GREEN}✓${RESET} %d chars\n" "${#result}"
 

--- a/tests/scenarios/retrieval/memory-rot/run-rot-test.sh
+++ b/tests/scenarios/retrieval/memory-rot/run-rot-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 
@@ -16,7 +16,7 @@ RESET=$(printf '\033[0m')
 
 mkdir -p "$RESULTS_DIR"
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local config_dir="$2"
     local output_file=$(mktemp)
@@ -62,7 +62,7 @@ Read and apply the following project memory:
 $(cat "$SCRIPT_DIR/month6/MEMORY.md" | head -200)" > "$REAL_CONFIG/rules/memory-sim.md"
 
     local result_memory
-    result_memory=$(run_claudia "$prompt" "$REAL_CONFIG")
+    result_memory=$(run_sandbox "$prompt" "$REAL_CONFIG")
     echo "$result_memory" > "$RESULTS_DIR/${prompt_name}_MEMORY-MONTH6.txt"
     printf "  ${GREEN}✓${RESET} Memory month-6 (%d chars)\n" "${#result_memory}"
 
@@ -77,7 +77,7 @@ $(cat "$SCRIPT_DIR/month6/MEMORY.md" | head -200)" > "$REAL_CONFIG/rules/memory-
         "$rules_src" > "$REAL_CONFIG/rules/distill.md"
 
     local result_distill
-    result_distill=$(run_claudia "$prompt" "$REAL_CONFIG")
+    result_distill=$(run_sandbox "$prompt" "$REAL_CONFIG")
     echo "$result_distill" > "$RESULTS_DIR/${prompt_name}_DISTILL.txt"
     printf "  ${GREEN}✓${RESET} Distill (%d chars)\n" "${#result_distill}"
 

--- a/tests/scenarios/retrieval/tool-reliability/run-tool-reliability-test.sh
+++ b/tests/scenarios/retrieval/tool-reliability/run-tool-reliability-test.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%d-%H%M%S)"
-REAL_CONFIG="$HOME/.claude-personal"
+REAL_CONFIG="${DISTILL_TEST_CONFIG:-$HOME/.claude}"
 CLAUDE_BIN="node /opt/homebrew/opt/claude-code-npm/libexec/lib/node_modules/@anthropic-ai/claude-code/cli.js"
 SANDBOX_PROFILE='(version 1)(allow default)(deny file-read* (literal "/Library/Application Support/ClaudeCode/managed-settings.json"))'
 RULES_SRC="$SCRIPT_DIR/../../../rules/distill.md"
@@ -20,7 +20,7 @@ mkdir -p "$RESULTS_DIR"
 
 PROMPT="I want you to set up a PR monitor that: (1) Checks the CI status of PR #42 every 3 minutes, (2) If CI fails, spawns a coding agent to fix the issue, (3) Once the fix is pushed, verifies CI passes. Give me the agent orchestration plan — what gets spawned, in what order, with what instructions."
 
-run_claudia() {
+run_sandbox() {
     local prompt="$1"
     local use_distill="${2:-no}"
     local output_file=$(mktemp)
@@ -90,13 +90,13 @@ printf "${DIM}2 conditions: vanilla, distill with operational knowledge${RESET}\
 
 # Condition A: No knowledge
 printf "\n  ${DIM}[A] Vanilla (no operational knowledge)...${RESET}\n"
-result_a=$(run_claudia "$PROMPT" "no")
+result_a=$(run_sandbox "$PROMPT" "no")
 echo "$result_a" > "$RESULTS_DIR/A-vanilla.txt"
 printf "  ${GREEN}✓${RESET} Vanilla (%d chars)\n" "${#result_a}"
 
 # Condition B: Distill with operational knowledge
 printf "\n  ${DIM}[B] Distill (operational knowledge from past failures)...${RESET}\n"
-result_b=$(run_claudia "$PROMPT" "yes")
+result_b=$(run_sandbox "$PROMPT" "yes")
 echo "$result_b" > "$RESULTS_DIR/B-distill.txt"
 printf "  ${GREEN}✓${RESET} Distill (%d chars)\n" "${#result_b}"
 


### PR DESCRIPTION
## Summary

- Renames `test-with-claudia.sh` → `test-sandbox.sh` and `run_claudia()` → `run_sandbox()` across all test scripts
- Replaces hardcoded `~/.claude-personal` with `DISTILL_TEST_CONFIG` env var (defaults to `~/.claude`)
- Removes all "claudia" references from docs, research pages, and project files
- INSTALL.md retains `~/.claude-personal` as a user-facing example of the `--profile` feature

## Test plan

- [x] `DISTILL_TEST_CONFIG=~/.claude-personal ./test-sandbox.sh install` — 17/17 passing
- [ ] Independent review via REVIEW-PROTOCOL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)