### PR TITLE
Fix version drift across surfaces + harden auto-bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -6,8 +6,11 @@ on:
     paths-ignore:
       - 'VERSION'
       - 'install.sh'
+      - 'install.ps1'
       - 'docs/header.svg'
+      - 'docs/index.html'
       - 'README.md'
+      - '.github/**'
 
 jobs:
   bump:
@@ -35,14 +38,18 @@ jobs:
           # Update VERSION file
           echo "$new_version" > VERSION
 
-          # Update install.sh
-          sed -i "s/VERSION=\"$current\"/VERSION=\"$new_version\"/" install.sh
+          # Pattern-based substitutions: match ANY x.y.z, not the current version.
+          # Matching the current version literally no-ops silently if a file ever
+          # drifts (this happened: README/header.svg sat at v0.7.0 through 1.1.x).
+          sed -i -E "s/^VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"/VERSION=\"$new_version\"/" install.sh
+          sed -i -E "s/^\\\$Version  = '[0-9]+\.[0-9]+\.[0-9]+'/\$Version  = '$new_version'/" install.ps1
+          # v1.2.3 in text and v=1.2.3 in the README's svg cache-buster
+          sed -i -E "s/v(=?)[0-9]+\.[0-9]+\.[0-9]+/v\1$new_version/g" docs/header.svg README.md docs/index.html
 
-          # Update header.svg
-          sed -i "s/v$current/v$new_version/g" docs/header.svg
-
-          # Update README.md
-          sed -i "s/v$current/v$new_version/g" README.md
+          # Fail loudly if any file did not pick up the new version
+          for f in VERSION install.sh install.ps1 README.md docs/header.svg docs/index.html; do
+            grep -q "$new_version" "$f" || { echo "::error::$f was not updated to $new_version"; exit 1; }
+          done
 
           echo "new_version=$new_version" >> $GITHUB_ENV
 
@@ -50,6 +57,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add VERSION install.sh docs/header.svg README.md
+          git add VERSION install.sh install.ps1 docs/header.svg docs/index.html README.md
           git commit -m "Bump version to v${new_version} [version-bump]" || echo "No changes to commit"
           git push

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -42,7 +42,8 @@ jobs:
           # Matching the current version literally no-ops silently if a file ever
           # drifts (this happened: README/header.svg sat at v0.7.0 through 1.1.x).
           sed -i -E "s/^VERSION=\"[0-9]+\.[0-9]+\.[0-9]+\"/VERSION=\"$new_version\"/" install.sh
-          sed -i -E "s/^\\\$Version  = '[0-9]+\.[0-9]+\.[0-9]+'/\$Version  = '$new_version'/" install.ps1
+          # [$] avoids backslash-escaping ambiguity for the literal dollar sign
+          sed -i -E "s/^([$]Version[[:space:]]+=[[:space:]]+')[0-9]+\.[0-9]+\.[0-9]+(')/\1$new_version\2/" install.ps1
           # v1.2.3 in text and v=1.2.3 in the README's svg cache-buster
           sed -i -E "s/v(=?)[0-9]+\.[0-9]+\.[0-9]+/v\1$new_version/g" docs/header.svg README.md docs/index.html
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,14 @@ When developing or testing:
 ## Version management
 
 - Current version is in `VERSION` file (semver)
-- `install.sh` has its own `VERSION` variable that must be kept in sync
-- Bump both when releasing
+- The auto-bump workflow (`.github/workflows/bump-version.yml`) bumps the patch version
+  on every content merge to main and syncs it across `VERSION`, `install.sh`,
+  `install.ps1`, `README.md`, `docs/header.svg`, and `docs/index.html`
+- After editing the workflow, run `./test-version-bump.sh` — it executes the run block
+  verbatim against fixture copies and asserts all six files update
+- The Homebrew formula (`homebrew/Formula/aura-distill.rb`) is NOT auto-bumped: it pins
+  a tagged release tarball + sha256, so updating it requires cutting a git tag and
+  recomputing the hash (manual release step)
 
 ## Key conventions
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,8 @@ EOF
 ### Step 4: Set the version
 
 ```bash
-echo "0.9.5" > "$PROFILE/distill/.version"
+curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/VERSION \
+  -o "$PROFILE/distill/.version"
 ```
 
 ### Step 5: (Optional) Disable built-in auto-memory

--- a/NEXT-STEPS.md
+++ b/NEXT-STEPS.md
@@ -39,6 +39,12 @@
 
 6. **Update landing page results section** with confidence scoring + decision fatigue data
 
+7. **Homebrew formula is stale at v1.0.0** (PR #27 review finding). README advertises
+   `brew install` as the primary macOS path, but the formula pins the v1.0.0 tarball +
+   sha256 and its test asserts "1.0.0". Can't be auto-bumped — needs a release process:
+   cut a git tag for the current version, recompute sha256, update url/sha256/test
+   assertion in `homebrew/Formula/aura-distill.rb`.
+
 ## Structural concerns to investigate
 
 7. Multi-file retrieval reliability (double-standards test showed gaps)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/header.svg?v=0.7.0" alt="aura-distill" width="800"/>
+  <img src="docs/header.svg?v=1.1.5" alt="aura-distill" width="800"/>
 </p>
 
 <p align="center">
@@ -170,5 +170,5 @@ Your knowledge files in `~/.claude/distill/` are preserved. They're yours.
 ---
 
 <p align="center">
-  <sub>v0.7.0 · MIT · Built for <a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a></sub>
+  <sub>v1.1.5 · MIT · Built for <a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a></sub>
 </p>

--- a/docs/header.svg
+++ b/docs/header.svg
@@ -98,5 +98,5 @@
   <text x="400" y="158" font-family="monospace" font-size="11" fill="#6a6a9a" text-anchor="middle">first-principles memory for Claude Code</text>
 
   <!-- Version -->
-  <text x="400" y="180" font-family="monospace" font-size="10" fill="#4a4a6a" text-anchor="middle">v0.7.0</text>
+  <text x="400" y="180" font-family="monospace" font-size="10" fill="#4a4a6a" text-anchor="middle">v1.1.5</text>
 </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2219,7 +2219,7 @@
 </div>
 
 <footer>
-    MIT &middot; Built for Claude Code &middot; v1.1.0
+    MIT &middot; Built for Claude Code &middot; v1.1.5
 </footer>
 
 <script>

--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$Version  = '0.7.2'
+$Version  = '1.1.5'
 $Build    = '20260515-01'
 $Repo     = 'https://raw.githubusercontent.com/tomacco/aura-distill/main'
 

--- a/test-version-bump.sh
+++ b/test-version-bump.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Verifies the auto-bump workflow's run block against fixture copies.
+# The script under test is extracted VERBATIM from bump-version.yml, so what
+# is tested is exactly what GitHub Actions executes — no re-typed variant.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+t=$(mktemp -d)
+trap 'rm -rf "$t"' EXIT
+
+cp VERSION install.sh install.ps1 README.md "$t/"
+mkdir -p "$t/docs"
+cp docs/header.svg docs/index.html "$t/docs/"
+
+awk '/current=\$\(cat VERSION/,/GITHUB_ENV/' .github/workflows/bump-version.yml \
+  | sed 's/^          //' | grep -v GITHUB_ENV > "$t/bump.sh"
+
+expected=$(awk -F. '{printf "%d.%d.%d", $1, $2, $3 + 1}' VERSION)
+
+(cd "$t" && bash bump.sh)
+
+# bump.sh already fails loudly per file; this is an independent assertion.
+for f in VERSION install.sh install.ps1 README.md docs/header.svg docs/index.html; do
+  grep -q "$expected" "$t/$f" || { echo "FAIL: $f not bumped to $expected"; exit 1; }
+done
+
+echo "OK: all 6 files bumped to $expected"


### PR DESCRIPTION
## What

Fixes the cross-file version drift flagged in PR #26's review, and the root cause behind it.

### Sync (all surfaces now 1.1.5)
- install.ps1: 0.7.2 → 1.1.5
- README.md: footer v0.7.0 → v1.1.5; header.svg cache-buster ?v=0.7.0 → ?v=1.1.5
- docs/header.svg: rendered v0.7.0 → v1.1.5
- docs/index.html: footer v1.1.0 → v1.1.5

### Root cause + hardening (bump-version.yml)
The auto-bump seds replaced the literal current version (`s/v$current/...`), so once a file drifted the substitution no-opped silently on every subsequent bump — README and header.svg sat at v0.7.0 through all of 1.1.x. Changes:
- Pattern-based seds (match any x.y.z) instead of literal current-version matches
- install.ps1 and docs/index.html added to the bump set (previously never updated by automation)
- Post-bump verification loop fails the job loudly if any file misses the new version
- .github/** added to paths-ignore so workflow-only merges don't bump the release version

Tested by executing the run block verbatim from the YAML against file copies: all six files updated on a simulated bump, verification loop passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
