### PR TITLE
Fix installer data loss: preserve Always-On User Preferences across updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to aura-distill.
 - **Landing page** `docs/token-saving.html` — the token-saving research line explained (inverted pyramid, SVG diagrams, measured numbers): what shipped, what's in research (learned spawn profiles), what became a trade-off knob instead of shipping (diet SPINE), what was corrected (naive friction accounting). Announced by the installer on update.
 - **Research pages**: `docs/research/token-economics.html` (40 days of real usage mined: ~85% of cost is context movement; distill overhead 5–6% of spend) and `docs/research/model-routing.html` (task-shape routing trials; orchestrators route near-optimally unaided).
 
+### Fixed
+- **Installer data loss**: updating overwrote `rules/distill.md` wholesale, wiping the user's synced "Always-On User Preferences" section back to the empty template (caught live-testing the v1.1.7 update). Both installers now preserve the section across updates (like SPINE) — only when it holds real content, not the template — and leave the existing file untouched if the download fails.
+
 ### Privacy
 - Token Saver collects nothing — local files only. Standing policy documented on the landing page: any future telemetry must be opt-in, aggregate-only, with a published schema.
 

--- a/install.ps1
+++ b/install.ps1
@@ -140,8 +140,43 @@ if (-not (Test-Path $spinePath)) {
 Write-Section 'Knowledge retrieval'
 
 if (-not (Test-Path $RulesDir)) { New-Item -ItemType Directory -Force -Path $RulesDir | Out-Null }
-Get-File "$Repo/rules/distill.md" (Join-Path $RulesDir 'distill.md')
-Write-Done "rules/distill.md ${DIM}(auto-loads every session)${RESET}"
+
+# Preserve the user's synced Always-On preferences across updates (like SPINE).
+# /distill writes real content into this section; overwriting it is data loss.
+$rulesTarget = Join-Path $RulesDir 'distill.md'
+$prefsMark = '## Always-On User Preferences'
+$preservedPrefs = $null
+if (Test-Path $rulesTarget) {
+    $existing = Get-Content $rulesTarget -Raw
+    $idx = $existing.IndexOf($prefsMark)
+    if ($idx -ge 0) {
+        $section = $existing.Substring($idx)
+        # Only preserve real content (a bold rule line), not the empty template
+        if ($section -match "(?m)^\*\*") { $preservedPrefs = $section }
+    }
+}
+$rulesTmp = [System.IO.Path]::GetTempFileName()
+try {
+    Get-File "$Repo/rules/distill.md" $rulesTmp
+    $fresh = Get-Content $rulesTmp -Raw
+    if ($fresh -match 'Distill') {
+        if ($preservedPrefs) {
+            $freshIdx = $fresh.IndexOf($prefsMark)
+            $body = if ($freshIdx -ge 0) { $fresh.Substring(0, $freshIdx) } else { $fresh }
+            Set-Content -Path $rulesTarget -Value ($body + $preservedPrefs) -Encoding utf8 -NoNewline
+            Write-Done "rules/distill.md ${DIM}(auto-loads every session; your preferences preserved)${RESET}"
+        } else {
+            Move-Item -Force $rulesTmp $rulesTarget
+            Write-Done "rules/distill.md ${DIM}(auto-loads every session)${RESET}"
+        }
+    } else {
+        Write-Warn 'rules/distill.md download invalid -- existing file left untouched'
+    }
+} catch {
+    Write-Warn 'rules/distill.md download failed -- existing file left untouched'
+} finally {
+    Remove-Item $rulesTmp -Force -ErrorAction SilentlyContinue
+}
 
 # === TOKEN SAVER (agent presets) ===
 # Full control via env var (installer runs through `irm | iex`, so no CLI flags):

--- a/install.ps1
+++ b/install.ps1
@@ -163,7 +163,7 @@ try {
         if ($preservedPrefs) {
             $freshIdx = $fresh.IndexOf($prefsMark)
             $body = if ($freshIdx -ge 0) { $fresh.Substring(0, $freshIdx) } else { $fresh }
-            Set-Content -Path $rulesTarget -Value ($body + $preservedPrefs) -Encoding utf8 -NoNewline
+            [System.IO.File]::WriteAllText($rulesTarget, ($body + $preservedPrefs), (New-Object System.Text.UTF8Encoding($false)))
             Write-Done "rules/distill.md ${DIM}(auto-loads every session; your preferences preserved)${RESET}"
         } else {
             Move-Item -Force $rulesTmp $rulesTarget

--- a/install.sh
+++ b/install.sh
@@ -245,8 +245,35 @@ fi
 show_section "Knowledge retrieval"
 
 mkdir -p "$RULES_DIR"
-curl -sL "$REPO/rules/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$RULES_DIR/distill.md"
-done_msg "rules/distill.md ${DIM}(auto-loads every session)${RESET}"
+
+# Preserve the user's synced Always-On preferences across updates (like SPINE).
+# /distill writes real content into this section; overwriting it is data loss.
+PREFS_MARK="## Always-On User Preferences"
+PREFS_TMP=""
+if [ -f "$RULES_DIR/distill.md" ] && grep -q "^$PREFS_MARK" "$RULES_DIR/distill.md" \
+   && grep -A 30 "^$PREFS_MARK" "$RULES_DIR/distill.md" | grep -q "^\*\*"; then
+    PREFS_TMP=$(mktemp)
+    sed -n "/^$PREFS_MARK/,\$p" "$RULES_DIR/distill.md" > "$PREFS_TMP"
+fi
+
+RULES_TMP=$(mktemp)
+if curl -fsL "$REPO/rules/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$RULES_TMP" \
+   && grep -q "Distill" "$RULES_TMP"; then
+    if [ -n "$PREFS_TMP" ]; then
+        # fresh body up to the marker + the user's preserved section
+        sed "/^$PREFS_MARK/,\$d" "$RULES_TMP" > "$RULES_DIR/distill.md"
+        cat "$PREFS_TMP" >> "$RULES_DIR/distill.md"
+        rm -f "$PREFS_TMP"
+        done_msg "rules/distill.md ${DIM}(auto-loads every session; your preferences preserved)${RESET}"
+    else
+        mv "$RULES_TMP" "$RULES_DIR/distill.md"
+        done_msg "rules/distill.md ${DIM}(auto-loads every session)${RESET}"
+    fi
+    rm -f "$RULES_TMP"
+else
+    rm -f "$RULES_TMP" "$PREFS_TMP"
+    warn_msg "rules/distill.md download failed — existing file left untouched"
+fi
 
 # ═══ TOKEN SAVER (agent presets) ═══
 # User has full control: --token-saver / --no-token-saver / --remove-token-saver.

--- a/install.sh
+++ b/install.sh
@@ -260,9 +260,12 @@ RULES_TMP=$(mktemp)
 if curl -fsL "$REPO/rules/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$RULES_TMP" \
    && grep -q "Distill" "$RULES_TMP"; then
     if [ -n "$PREFS_TMP" ]; then
-        # fresh body up to the marker + the user's preserved section
-        sed "/^$PREFS_MARK/,\$d" "$RULES_TMP" > "$RULES_DIR/distill.md"
-        cat "$PREFS_TMP" >> "$RULES_DIR/distill.md"
+        # Build the merged file in a temp and move it into place atomically —
+        # never truncate the live file before the merge is complete.
+        MERGED_TMP=$(mktemp)
+        sed "/^$PREFS_MARK/,\$d" "$RULES_TMP" > "$MERGED_TMP"
+        cat "$PREFS_TMP" >> "$MERGED_TMP"
+        mv "$MERGED_TMP" "$RULES_DIR/distill.md"
         rm -f "$PREFS_TMP"
         done_msg "rules/distill.md ${DIM}(auto-loads every session; your preferences preserved)${RESET}"
     else


### PR DESCRIPTION
## The bug

Live-testing the v1.1.7 update on a real profile: the installer overwrites `rules/distill.md` unconditionally, wiping the user's /distill-synced **Always-On User Preferences** section back to the empty template. This is user data written by /distill — every updating user with synced preferences loses them.

## The fix

Both installers now treat the section like SPINE:
- extract the existing `## Always-On User Preferences` section when it holds real content (a `**`-rule line — template-only sections are not preserved)
- write the fresh body + preserved section **atomically** (temp + move; the live file is never truncated mid-merge)
- on download failure/invalid payload, leave the existing file untouched (previously: clobbered with whatever curl produced)
- ps1 writes BOM-free UTF-8 on PowerShell 5.1 (explicit UTF8Encoding(false))

## Tested

Sandboxed (mktemp HOME/USERPROFILE): preserve path, fresh-install path, template-only path (sh, live fetches); extracted-block harness against live repo (ps1). Independent clean-context review per REVIEW-PROTOCOL: **APPROVE** — its two LOW findings (atomicity, BOM) are fixed in the second commit; its VERY LOW hardening note (discriminator coupling to `**` formatting) is documented for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)