### PR TITLE
Economics ledger: /distill measures and records its own token cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@ All notable changes to aura-distill.
 ## [Unreleased]
 
 ### Added
-- **Economics ledger**: `/distill` now records its own cost — after each run, one JSONL line is appended to `{DISTILL_DIR}/data/economics.jsonl` (distillation tokens, tokens written, SPINE size, total KB size, signal count). Local data only, never synced. The distillation report gains an Economics line, and compaction now weighs recurring-cost tokens (SPINE, always-on) heavier than pay-per-read tier files — with an explicit integrity floor: [NON-NEGOTIABLE]/[DIRECTIVE]/safety entries are never compressed for token savings.
-
-
-### Added
+- **Economics ledger**: `/distill` now records its own cost — after each run, one JSONL line is appended to `{DISTILL_DIR}/data/economics.jsonl` (fields including timestamp, distillation tokens when available, tokens written, SPINE size, tier-file KB size, signal and file counts). Local diagnostic data, not part of the synced knowledge set. The distillation report gains an Economics line, and compaction now weighs recurring-cost tokens (SPINE, always-on) heavier than pay-per-read tier files — with an explicit integrity floor: [NON-NEGOTIABLE]/[DIRECTIVE]/safety entries are never compressed for token savings.
 - **Token Saver** — two preset subagents installed to the profile's `agents/` directory (`~/.claude/agents/` by default; install.sh honors `--profile`): `scribe` (text-only jobs: judge/summarize/classify/extract/draft — no tools, boots ~2k tokens vs ~19–27k default, measured 14x lighter) and `scout` (read-only exploration: Glob/Grep/Read — ~3.5x lighter, cannot modify anything). Backed by the July 2026 token-economics research (tool schemas ≈22k of a default spawn's ~27k starting context).
 - **Full user control** for Token Saver: `--token-saver` / `--no-token-saver` / `--remove-token-saver` flags (install.sh) and `$env:DISTILL_TOKEN_SAVER` = `on`/`off`/`remove` (install.ps1). Choice persists across updates via `distill/.token-saver`. Installer never overwrites agent files it didn't create.
 - **Landing page** `docs/token-saving.html` — the token-saving research line explained (inverted pyramid, SVG diagrams, measured numbers): what shipped, what's in research (learned spawn profiles), what became a trade-off knob instead of shipping (diet SPINE), what was corrected (naive friction accounting). Announced by the installer on update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to aura-distill.
 ## [Unreleased]
 
 ### Added
+- **Economics ledger**: `/distill` now records its own cost — after each run, one JSONL line is appended to `{DISTILL_DIR}/data/economics.jsonl` (distillation tokens, tokens written, SPINE size, total KB size, signal count). Local data only, never synced. The distillation report gains an Economics line, and compaction now weighs recurring-cost tokens (SPINE, always-on) heavier than pay-per-read tier files — with an explicit integrity floor: [NON-NEGOTIABLE]/[DIRECTIVE]/safety entries are never compressed for token savings.
+
+
+### Added
 - **Token Saver** — two preset subagents installed to the profile's `agents/` directory (`~/.claude/agents/` by default; install.sh honors `--profile`): `scribe` (text-only jobs: judge/summarize/classify/extract/draft — no tools, boots ~2k tokens vs ~19–27k default, measured 14x lighter) and `scout` (read-only exploration: Glob/Grep/Read — ~3.5x lighter, cannot modify anything). Backed by the July 2026 token-economics research (tool schemas ≈22k of a default spawn's ~27k starting context).
 - **Full user control** for Token Saver: `--token-saver` / `--no-token-saver` / `--remove-token-saver` flags (install.sh) and `$env:DISTILL_TOKEN_SAVER` = `on`/`off`/`remove` (install.ps1). Choice persists across updates via `distill/.token-saver`. Installer never overwrites agent files it didn't create.
 - **Landing page** `docs/token-saving.html` — the token-saving research line explained (inverted pyramid, SVG diagrams, measured numbers): what shipped, what's in research (learned spawn profiles), what became a trade-off knob instead of shipping (diet SPINE), what was corrected (naive friction accounting). Announced by the installer on update.

--- a/distill-process.md
+++ b/distill-process.md
@@ -643,6 +643,25 @@ Memory pressure: X/10 → Y/10
 
 After encoding new learnings, maintain tier health:
 
+### Economics accounting (every distillation)
+
+Distill optimizes for memory quality AND token economics. Measure — never estimate from
+memory — using chars/4 as the token approximation:
+
+1. Sum the sizes of every file you WROTE or EDITED this run → `written_tokens`
+2. Size of SPINE.md after your updates → `spine_tokens`
+3. Total size of all tier files (`profile/ ops/ craft/ projects/ feedback/`, excluding
+   `archive/`) → `kb_tokens`
+4. Include all three in your report's **Economics** line.
+
+Why it matters: the SPINE is carried in context on every request of every session — each
+token added to it is a recurring cost, not a one-time one. Tier-2 files are lazy-loaded
+(pay-per-read), so detail belongs THERE, pointers in the SPINE. When compacting, weigh
+recurring-cost tokens (SPINE, always-on) heavier than pay-per-read tokens (tier files).
+Economics NEVER overrides integrity: never drop or compress a [NON-NEGOTIABLE], [DIRECTIVE],
+or safety-relevant entry to save tokens — verbatim fidelity wins there, and rare-but-
+catastrophic knowledge is worth more than any token math suggests.
+
 ### Spine compaction (if > 60 lines)
 1. Merge entries pointing to the same domain
 2. Entries whose Tier 2 files haven't been updated in 90+ days → ask user if still relevant

--- a/distill.md
+++ b/distill.md
@@ -132,6 +132,7 @@ Return a distillation report:
 - Learnings encoded: list with file paths
 - User model updates: what changed
 - Tier health: current state
+- Economics: tokens written this run (sum of chars/4 across files you wrote), SPINE size in tokens (chars/4), total KB size in tokens (sum over all tier files)
 - Flagged tensions: any honesty-vs-comfort conflicts
 - Open questions: anything you couldn't resolve without asking the user
 `
@@ -144,9 +145,18 @@ When the sub-agent completes:
 
 1. **Read the spine** — `Read {DISTILL_DIR}/SPINE.md` to bring the updated knowledge index into the current session context. This is how the current session benefits immediately from what was just distilled.
 
-2. **Relay the report** to the user concisely. Only surface:
+2. **Record the economics ledger** — append ONE line to `{DISTILL_DIR}/data/economics.jsonl` (create the `data/` directory if missing). Distill optimizes for memory quality AND token economics; a system that never measures its own cost cannot claim to save anything. The line:
+
+```json
+{"ts":"<ISO-8601 UTC>","distill_tokens":<subagent token total from the Agent tool result's usage, or null if unavailable>,"written_tokens":<from report>,"spine_tokens":<from report>,"kb_tokens":<from report>,"signals":<N>,"files_written":<count>}
+```
+
+   Rules: append-only, one JSON object per line, no rewriting past lines. If a value is unknown, use `null` — never invent numbers. This file is local data, never synced anywhere.
+
+3. **Relay the report** to the user concisely. Only surface:
    - What was learned (the principles, not the raw signals)
    - Where it was saved
+   - One economics line (cost of this distillation + current KB footprint — from the ledger entry)
    - Any open questions that need user input
    - Any flagged tensions
 

--- a/distill.md
+++ b/distill.md
@@ -132,7 +132,7 @@ Return a distillation report:
 - Learnings encoded: list with file paths
 - User model updates: what changed
 - Tier health: current state
-- Economics: tokens written this run (sum of chars/4 across files you wrote), SPINE size in tokens (chars/4), total KB size in tokens (sum over all tier files)
+- Economics: tokens written this run (sum of chars/4 across files you wrote), SPINE size in tokens (chars/4), tier-file KB size in tokens (sum over tier files, excludes SPINE and archive/), and the COUNT of files written
 - Flagged tensions: any honesty-vs-comfort conflicts
 - Open questions: anything you couldn't resolve without asking the user
 `
@@ -148,10 +148,10 @@ When the sub-agent completes:
 2. **Record the economics ledger** — append ONE line to `{DISTILL_DIR}/data/economics.jsonl` (create the `data/` directory if missing). Distill optimizes for memory quality AND token economics; a system that never measures its own cost cannot claim to save anything. The line:
 
 ```json
-{"ts":"<ISO-8601 UTC>","distill_tokens":<subagent token total from the Agent tool result's usage, or null if unavailable>,"written_tokens":<from report>,"spine_tokens":<from report>,"kb_tokens":<from report>,"signals":<N>,"files_written":<count>}
+{"ts":"<ISO-8601 UTC>","distill_tokens":<subagent token total ONLY if the harness surfaced a real usage figure for the spawned agent; otherwise null — this value is usually NOT available to you: default to null, NEVER estimate>,"written_tokens":<from report>,"spine_tokens":<from report>,"kb_tokens":<from report>,"signals":<N>,"files_written":<count from report>}
 ```
 
-   Rules: append-only, one JSON object per line, no rewriting past lines. If a value is unknown, use `null` — never invent numbers. This file is local data, never synced anywhere.
+   Rules: append-only, one JSON object per line, no rewriting past lines. If a value is unknown, use `null` — never invent numbers. This file is local diagnostic data, not part of the synced knowledge set; distill itself never transmits it.
 
 3. **Relay the report** to the user concisely. Only surface:
    - What was learned (the principles, not the raw signals)


### PR DESCRIPTION
## What

Economics becomes a first-class distill objective alongside memory quality:

- The distillation report gains an **Economics** line: tokens written (chars/4, measured never estimated), SPINE size, tier-file KB size, files written.
- After each run the main context appends one line to `{DISTILL_DIR}/data/economics.jsonl` (append-only; `null` for unknowable values — explicitly never estimated). Local diagnostic data, not part of the synced knowledge set.
- Compaction guidance: recurring-cost tokens (SPINE, always-on — re-read every request) weigh heavier than pay-per-read tier files, under a hard integrity floor: **[NON-NEGOTIABLE]/[DIRECTIVE]/safety entries are never compressed for token savings**.

## Why

July-2026 token-economics research: SPINE carry is re-priced on every request (measured $12/window at 3.6k tokens); distill's honest verdict is "token shaper, not proven saver" until it measures itself. This is the measurement half. Feeds the metering research line and future evidence-based (token-budget) caps.

## Review

Independent clean-context review per REVIEW-PROTOCOL: REQUEST CHANGES → all 5 findings fixed in the second commit (emphatic null-not-estimate for distill_tokens, changelog structure/accuracy, sync-claim accuracy, field sourcing). Follow-up noted: nothing consumes the ledger yet (dashboard candidate); pre-existing threshold discrepancy (process 60/45 vs CLAUDE.md 80/60) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)