### PR TITLE
Add shared Claude and Codex knowledge store

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## What this is
 
-A first-principles memory system for Claude Code. Users install it via `install.sh`, which places files into `~/.claude/distill/`. The `/distill` slash command triggers retrospective distillation of conversation signals into tiered knowledge files.
+A first-principles memory system shared by Claude Code and Codex. Users install it via `install.sh` or `install.ps1`, which places knowledge in `~/.aura-distill/` and adds client adapters. Claude can trigger it with `/distill`; Codex users ask it to distill.
 
 ## Architecture
 
 - `distill.md` — Dispatcher (runs in main context, harvests signals, spawns sub-agent)
 - `distill-process.md` — Sub-agent instructions (the full distillation pipeline)
-- `distill-monitor.md` — Session-start monitor (minimal, loaded via `rules/distill.md`)
+- `distill-monitor.md` — Session-start monitor (minimal, loaded via the client integration)
 - `knowledge-architecture.md` — Tier system design doc
 - `install.sh` / `install.ps1` — User-facing installers
 - `tests/` — A/B test scenarios, cognitive bias tests, persona-based methodology tests
@@ -17,7 +17,7 @@ A first-principles memory system for Claude Code. Users install it via `install.
 
 ## CRITICAL: Never touch real user data
 
-**NEVER read, write, or test against real Claude profile directories on this machine.**
+**NEVER read, write, or test against real Claude/Codex profile directories or `~/.aura-distill` on this machine.**
 
 These directories contain the developer's real distilled knowledge. An errant write, backup, or test run against them risks data loss (this has already happened once — see the `_distill_isolation_bak` incident).
 
@@ -55,6 +55,8 @@ When developing or testing:
 - Test personas: Sofia (senior backend engineer) and Marcus (product manager)
 - Run persona tests: `./tests/scenarios/methodology/run-persona-test.sh`
 - Run integration tests: `./test-sandbox.sh`
+- Run deterministic Claude/Codex installer tests: `pwsh tests/test-codex.ps1`
+- Run a real isolated Codex retrieval test: `pwsh tests/test-codex.ps1 -LiveRetrieval`
 
 ## PR reviews
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,19 @@
 
 Three installation methods, from automated to fully manual.
 
+## Shared Claude + Codex layout
+
+New installations keep the knowledge base in `~/.aura-distill/`. Claude's
+`CLAUDE.md` and Codex's global `~/.codex/AGENTS.md` receive small managed
+pointers to the same `SPINE.md`, so both clients recall and update one source
+of truth.
+
+When the installer finds an older Claude-only knowledge base at
+`~/.claude/distill/`, it copies that knowledge into the shared directory and
+leaves the legacy directory untouched. Re-running the installer is idempotent:
+managed instruction blocks are replaced in place and unrelated user guidance
+is preserved.
+
 ---
 
 ## Method 1: Script (one command)
@@ -43,7 +56,9 @@ For security-conscious users who don't pipe curl to bash.
 ### Step 1: Download the files
 
 ```bash
-# Choose your profile directory (default: ~/.claude)
+# Shared knowledge directory (default for every client)
+DISTILL_DIR="$HOME/.aura-distill"
+# Claude adapter directory
 PROFILE="$HOME/.claude"
 
 # Core command (the /distill slash command)
@@ -52,11 +67,11 @@ curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/distill.md 
 
 # Process engine (how /distill works internally)
 curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/distill-process.md \
-  -o "$PROFILE/distill/distill-process.md"
+  -o "$DISTILL_DIR/distill-process.md"
 
 # Session monitor (loaded every session, tiny)
 curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/distill-monitor.md \
-  -o "$PROFILE/distill/distill-monitor.md"
+  -o "$DISTILL_DIR/distill-monitor.md"
 
 # Retrieval rules (auto-loads, tells Claude how to use knowledge)
 curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/rules/distill.md \
@@ -66,15 +81,16 @@ curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/rules/disti
 ### Step 2: Create the directory structure
 
 ```bash
-mkdir -p "$PROFILE/distill"/{craft,ops,profile,projects,feedback,archive}
+mkdir -p "$DISTILL_DIR"/{craft,ops,profile,projects,feedback,archive}
 mkdir -p "$PROFILE/commands"
 mkdir -p "$PROFILE/rules"
+mkdir -p "$HOME/.codex"
 ```
 
 ### Step 3: Initialize the SPINE
 
 ```bash
-cat > "$PROFILE/distill/SPINE.md" << 'EOF'
+cat > "$DISTILL_DIR/SPINE.md" << 'EOF'
 # Distill Knowledge Index
 
 <!-- This file is managed by aura-distill. Max 80 lines. -->
@@ -86,7 +102,7 @@ EOF
 
 ```bash
 curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/VERSION \
-  -o "$PROFILE/distill/.version"
+  -o "$DISTILL_DIR/.version"
 ```
 
 ### Step 5: (Optional) Disable built-in auto-memory
@@ -99,15 +115,15 @@ Distill owns knowledge management. To prevent Claude's built-in memory from conf
 echo '{ "autoMemoryEnabled": false }' > "$PROFILE/settings.json"
 ```
 
-### Step 6: (Optional) Add CLAUDE.md gate
+### Step 6: Add Claude and Codex integration pointers
 
-Add to your `$PROFILE/CLAUDE.md`:
+Add this managed guidance to both `$PROFILE/CLAUDE.md` and `$HOME/.codex/AGENTS.md`:
 
 ```markdown
-# Distill — knowledge system (github.com/tomacco/aura-distill)
-
-GATE: If ~/.claude/distill/.needs-migration exists AND its content does not start with "migrated",
-tell the user: "Run /distill to migrate existing memories." Do NOT proceed until addressed or declined.
+<!-- aura-distill:start -->
+# Aura Distill shared knowledge
+Before doing any work, read ~/.aura-distill/distill-monitor.md and ~/.aura-distill/SPINE.md. If the task matches a SPINE entry, read the linked file before responding and apply it.
+<!-- aura-distill:end -->
 ```
 
 ---
@@ -141,11 +157,13 @@ If only `~/.claude/` exists, the installer uses it automatically. No `--profile`
 | File | Location | Purpose |
 |------|----------|---------|
 | `distill.md` | `$PROFILE/commands/` | The `/distill` slash command |
-| `distill-process.md` | `$PROFILE/distill/` | How distillation works (sub-agent reads this) |
-| `distill-monitor.md` | `$PROFILE/distill/` | Session monitor (pressure tracking) |
+| `distill-process.md` | `~/.aura-distill/` | How distillation works (sub-agent reads this) |
+| `distill-monitor.md` | `~/.aura-distill/` | Session monitor (pressure tracking) |
 | `distill.md` (rules) | `$PROFILE/rules/` | Retrieval rules (auto-loaded every session) |
-| `SPINE.md` | `$PROFILE/distill/` | Knowledge index (you'll add entries here) |
-| `.version` | `$PROFILE/distill/` | Installed version (for update checks) |
+| `SPINE.md` | `~/.aura-distill/` | Shared knowledge index |
+| `.version` | `~/.aura-distill/` | Installed version (for update checks) |
+| managed pointer | `~/.claude/CLAUDE.md` | Claude integration |
+| managed pointer | `~/.codex/AGENTS.md` | Codex integration |
 
 **Total: 5 files + 1 index. No dependencies. No Node.js. No database.**
 
@@ -153,10 +171,10 @@ If only `~/.claude/` exists, the installer uses it automatically. No `--profile`
 
 ## Verifying installation
 
-After installing, start a new Claude Code session and say:
+After installing, start a new Claude Code or Codex session and say:
 
 ```
-Read ~/.claude/distill/SPINE.md
+Read ~/.aura-distill/SPINE.md
 ```
 
 If Claude reads it without error, the installation is working. The rules file will make Claude read the SPINE automatically at session start.
@@ -168,10 +186,8 @@ If Claude reads it without error, the installation is working. The rules file wi
 ```bash
 rm -f "$PROFILE/commands/distill.md"
 rm -f "$PROFILE/rules/distill.md"
-rm -f "$PROFILE/distill/distill-process.md"
-rm -f "$PROFILE/distill/distill-monitor.md"
-rm -f "$PROFILE/distill/.version"
-# Your knowledge files in $PROFILE/distill/ are preserved
+# Remove the managed aura-distill blocks from CLAUDE.md and ~/.codex/AGENTS.md.
+# Keep ~/.aura-distill/ unless you intentionally want to delete your knowledge.
 ```
 
 ---

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,6 +60,7 @@ For security-conscious users who don't pipe curl to bash.
 DISTILL_DIR="$HOME/.aura-distill"
 # Claude adapter directory
 PROFILE="$HOME/.claude"
+mkdir -p "$DISTILL_DIR" "$PROFILE/commands" "$PROFILE/rules"
 
 # Core command (the /distill slash command)
 curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/distill.md \
@@ -76,6 +77,13 @@ curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/distill-mon
 # Retrieval rules (auto-loads, tells Claude how to use knowledge)
 curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/rules/distill.md \
   -o "$PROFILE/rules/distill.md"
+
+# Resolve the shared-store placeholder in every installed adapter/process file.
+sed -i "s|{DISTILL_DIR}|$DISTILL_DIR|g" \
+  "$PROFILE/commands/distill.md" \
+  "$PROFILE/rules/distill.md" \
+  "$DISTILL_DIR/distill-process.md" \
+  "$DISTILL_DIR/distill-monitor.md"
 ```
 
 ### Step 2: Create the directory structure
@@ -122,15 +130,33 @@ Add this managed guidance to both `$PROFILE/CLAUDE.md` and `$HOME/.codex/AGENTS.
 ```markdown
 <!-- aura-distill:start -->
 # Aura Distill shared knowledge
-Before doing any work, read ~/.aura-distill/distill-monitor.md and ~/.aura-distill/SPINE.md. If the task matches a SPINE entry, read the linked file before responding and apply it.
+Before doing any work, read ~/.aura-distill/SPINE.md. If the task matches a SPINE entry, read the linked file before responding and apply it.
 <!-- aura-distill:end -->
 ```
+
+In Codex's `AGENTS.md`, also tell Codex to read
+`~/.aura-distill/distill-monitor.md` for the complete retrieval and
+memory-pressure behavior.
+
+Because the shared store sits outside a repository workspace, sandboxed Codex
+sessions may request permission before writing distilled knowledge. In the CLI,
+you can grant that directory explicitly with
+`codex --sandbox workspace-write --add-dir ~/.aura-distill`. Retrieval remains
+read-only; the extra writable root is needed only when Codex runs distillation.
 
 ---
 
 ## Multi-profile support
 
-Claude Code supports multiple config profiles at `~/.claude-<name>/`. Each profile is independent — its own rules, commands, knowledge, and settings.
+Claude Code supports multiple config profiles at `~/.claude-<name>/`. Their
+Claude rules, commands, and settings remain independent, but by default they
+share the client-neutral knowledge in `~/.aura-distill/` with Codex. To retain
+an isolated knowledge base for a profile, set `AURA_DISTILL_HOME` before
+installing that profile (for example, `~/.aura-distill-work`).
+
+Only the first legacy profile is automatically copied into a new shared store.
+Later legacy stores are left untouched and reported by the installer so they
+can be merged deliberately instead of silently overwriting shared knowledge.
 
 **Detecting profiles:**
 ```bash

--- a/MECHANISMS.md
+++ b/MECHANISMS.md
@@ -20,7 +20,7 @@ Living document of the mechanisms in aura-distill, their current state, and impr
 
 | Mechanism | Status | How it works | Known gaps |
 |-----------|--------|--------------|------------|
-| Spine auto-load | v0.2.0 | Monitor tells session to read SPINE.md at start | Only works if CLAUDE.md line is present |
+| Spine auto-load | v1.2.0 | Managed blocks in Claude `CLAUDE.md` and Codex `AGENTS.md` point to the shared SPINE | Depends on clients loading their global instruction files |
 | Post-distill spine read | v0.2.0 | Dispatcher reads SPINE after sub-agent returns | Only for current session |
 | Bridge detection | v0.3.2 | Step 3b identifies unreachable knowledge | Only suggests — user must act |
 | Bridge escalation | v0.3.2 | Repeated suggestion + frustration → louder prompt | No tracking of "how many times suggested" yet |

--- a/MECHANISMS.md
+++ b/MECHANISMS.md
@@ -20,7 +20,7 @@ Living document of the mechanisms in aura-distill, their current state, and impr
 
 | Mechanism | Status | How it works | Known gaps |
 |-----------|--------|--------------|------------|
-| Spine auto-load | v1.2.0 | Managed blocks in Claude `CLAUDE.md` and Codex `AGENTS.md` point to the shared SPINE | Depends on clients loading their global instruction files |
+| Spine auto-load | next release | Managed blocks in Claude `CLAUDE.md` and Codex `AGENTS.md` point to the shared SPINE | Depends on clients loading their global instruction files |
 | Post-distill spine read | v0.2.0 | Dispatcher reads SPINE after sub-agent returns | Only for current session |
 | Bridge detection | v0.3.2 | Step 3b identifies unreachable knowledge | Only suggests — user must act |
 | Bridge escalation | v0.3.2 | Repeated suggestion + frustration → louder prompt | No tracking of "how many times suggested" yet |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ you type /distill
 
 ```
 ~/
-├── .claude/CLAUDE.md              ← managed pointer for Claude
+├── .claude/CLAUDE.md               ← managed pointer for Claude
 ├── .codex/AGENTS.md                ← managed pointer for Codex
 └── .aura-distill/                  ← shared, client-neutral knowledge
     ├── SPINE.md                     ← tier 1: index (max 80 lines)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>Not what it remembers — how it learns.</strong><br>
-  <em>First-principles memory for Claude Code. A/B tested.</em>
+  <em>First-principles memory for Claude Code and Codex. A/B tested.</em>
 </p>
 
 <p align="center">
@@ -58,7 +58,7 @@ curl -sL https://raw.githubusercontent.com/tomacco/aura-distill/main/install.sh 
 irm https://raw.githubusercontent.com/tomacco/aura-distill/main/install.ps1 | iex
 ```
 
-<sub>No sudo, writes only to `~/.claude/` (`%USERPROFILE%\.claude\` on Windows). [Read install.sh](install.sh) / [install.ps1](install.ps1) first if you're the responsible kind.</sub>
+<sub>No sudo. Knowledge lives in `~/.aura-distill/`; small adapters are added to Claude and Codex configuration. [Read install.sh](install.sh) / [install.ps1](install.ps1) first if you're the responsible kind.</sub>
 
 This installs:
 
@@ -66,8 +66,10 @@ This installs:
 |------|----------|---------|
 | `distill.md` | `~/.claude/commands/` | The `/distill` slash command |
 | `distill.md` | `~/.claude/rules/` | Knowledge retrieval (18 lines, auto-loads every session) |
-| `distill-process.md` | `~/.claude/distill/` | Full process (read by sub-agent) |
-| `SPINE.md` | `~/.claude/distill/` | Knowledge index |
+| `distill-process.md` | `~/.aura-distill/` | Full process (read by sub-agent) |
+| `SPINE.md` | `~/.aura-distill/` | Shared Claude/Codex knowledge index |
+| managed pointer | `~/.claude/CLAUDE.md` | Makes Claude load the shared SPINE |
+| managed pointer | `~/.codex/AGENTS.md` | Makes Codex load the shared SPINE |
 
 Zero dependencies. No Node.js. No MCP server. No database. Just files.
 
@@ -80,7 +82,7 @@ you type /distill
     → harvests signals from the conversation (corrections, preferences, surprises)
     → spawns an isolated sub-agent (your context stays clean)
     → sub-agent traces each signal to a first principle
-    → encodes in ~/.claude/distill/ with markers: [UPDATED], [CONTEXT], [NON-NEGOTIABLE]
+    → encodes in ~/.aura-distill/ with markers: [UPDATED], [CONTEXT], [NON-NEGOTIABLE]
     → every future session retrieves relevant knowledge before responding
 ```
 
@@ -109,11 +111,10 @@ you type /distill
 ## Architecture
 
 ```
-~/.claude/
-├── CLAUDE.md                        ← one line added (gate for migration)
-├── rules/
-│   └── distill.md                   ← retrieval engine (18 lines, auto-loaded)
-└── distill/
+~/
+├── .claude/CLAUDE.md              ← managed pointer for Claude
+├── .codex/AGENTS.md                ← managed pointer for Codex
+└── .aura-distill/                  ← shared, client-neutral knowledge
     ├── SPINE.md                     ← tier 1: index (max 80 lines)
     ├── distill-process.md           ← the distillation process
     ├── craft/                       ← tier 2: discipline knowledge
@@ -156,19 +157,21 @@ brew uninstall aura-distill
 **macOS / Linux / WSL:**
 ```bash
 rm -f ~/.claude/commands/distill.md ~/.claude/rules/distill.md
-rm -f ~/.claude/distill/distill-process.md ~/.claude/distill/distill-monitor.md ~/.claude/distill/.version
+# Remove the managed aura-distill blocks from ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md.
+# Keep ~/.aura-distill/ unless you intentionally want to delete your knowledge.
 ```
 
 **Windows** (PowerShell):
 ```powershell
 Remove-Item -Force $HOME\.claude\commands\distill.md, $HOME\.claude\rules\distill.md
-Remove-Item -Force $HOME\.claude\distill\distill-process.md, $HOME\.claude\distill\distill-monitor.md, $HOME\.claude\distill\.version
+# Remove the managed aura-distill blocks from CLAUDE.md and AGENTS.md.
+# Keep $HOME\.aura-distill unless you intentionally want to delete your knowledge.
 ```
 
-Your knowledge files in `~/.claude/distill/` are preserved. They're yours.
+Your knowledge files in `~/.aura-distill/` are preserved. They're yours.
 
 ---
 
 <p align="center">
-  <sub>v1.1.10 · MIT · Built for <a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a></sub>
+  <sub>v1.1.10 · MIT · Built for Claude Code and Codex</sub>
 </p>

--- a/distill-monitor.md
+++ b/distill-monitor.md
@@ -1,6 +1,6 @@
 # Distill: Session Monitor
 
-This file is loaded at the start of every Claude Code session. It is intentionally small to minimize context cost.
+This file is referenced by the Claude and Codex integration blocks. It is intentionally small to minimize context cost.
 
 ## MANDATORY: Knowledge retrieval
 
@@ -12,7 +12,7 @@ This file is loaded at the start of every Claude Code session. It is intentional
 
 ## Knowledge ownership (critical)
 
-**Distill owns ALL persistent knowledge management.** Do NOT use Claude Code's built-in auto-memory system (`memory/` files, `MEMORY.md`) for learnings, corrections, preferences, or user model observations.
+**Distill owns ALL persistent knowledge management.** Do NOT write competing persistent memories in a client's private memory store for learnings, corrections, preferences, or user model observations.
 
 When you detect something worth remembering (a correction, a preference, a frustration, a learning):
 - Do NOT write it to `memory/` files

--- a/distill.md
+++ b/distill.md
@@ -1,6 +1,6 @@
 # Retrospective Distillation
 
-> **MANDATORY**: This command MUST execute via a spawned sub-agent. NEVER run the distillation process in the main conversation context. The main context is precious — distillation would consume it and defeat the purpose.
+> **MANDATORY**: This workflow MUST execute via an isolated sub-agent when the client supports sub-agents. NEVER run the distillation process in the main conversation context unless isolation is unavailable and the user explicitly accepts the context cost.
 
 ## What you MUST do (exactly in this order)
 
@@ -89,9 +89,9 @@ Write all of this down as a structured summary. Be thorough — anything you don
 
 ### Step 2: Spawn the distillation agent
 
-Use the Agent tool. The sub-agent receives the FULL distillation process plus your harvested signals.
+Use the client's sub-agent/delegation tool (Claude's Agent tool or Codex sub-agents). The sub-agent receives the FULL distillation process plus your harvested signals.
 
-**IMPORTANT: The distillation agent MUST be spawned in FOREGROUND (do NOT use `run_in_background: true`).** Background agents cannot write files because permission prompts are suppressed. The distillation agent's sole purpose is writing files — it MUST run in foreground so that Edit/Write permissions from settings.local.json are honored.
+**IMPORTANT:** Keep the distillation agent attached until it completes. It must have write access to `{DISTILL_DIR}/`; do not use a mode that suppresses required write permissions.
 
 ```
 Agent({

--- a/distill.md
+++ b/distill.md
@@ -91,7 +91,7 @@ Write all of this down as a structured summary. Be thorough — anything you don
 
 Use the client's sub-agent/delegation tool (Claude's Agent tool or Codex sub-agents). The sub-agent receives the FULL distillation process plus your harvested signals.
 
-**IMPORTANT:** Keep the distillation agent attached until it completes. It must have write access to `{DISTILL_DIR}/`; do not use a mode that suppresses required write permissions.
+**IMPORTANT:** Keep the distillation agent attached until it completes. It must have write access to `{DISTILL_DIR}/`; do not use a mode that suppresses required write permissions. In Claude Code specifically, never use `run_in_background: true`: background agents cannot obtain the write permissions this workflow requires.
 
 ```
 Agent({

--- a/install.ps1
+++ b/install.ps1
@@ -121,6 +121,8 @@ if ((Test-Path $LegacyDistillDir) -and ($LegacyDistillDir -ne $DistillDir) -and 
     Copy-Item -Path (Join-Path $LegacyDistillDir '*') -Destination $DistillDir -Recurse -Force -ErrorAction SilentlyContinue
     "copied from $LegacyDistillDir on $((Get-Date).ToUniversalTime().ToString('s'))Z" | Set-Content $legacyMarker -NoNewline
     Write-Info 'Existing Claude knowledge copied to shared store; legacy files preserved'
+} elseif ((Test-Path $LegacyDistillDir) -and (Test-Path $legacyMarker)) {
+    Write-Info "Shared store was already seeded; $LegacyDistillDir left untouched (set AURA_DISTILL_HOME for an isolated profile)"
 }
 
 Get-File "$Repo/distill.md"          (Join-Path $CmdDir 'distill.md')
@@ -287,7 +289,7 @@ if (Test-Path $SettingsJson) {
 }
 
 function Set-AuraIntegration {
-    param([string]$Path, [string]$Label)
+    param([string]$Path, [string]$Label, [ValidateSet('claude','codex')][string]$Client)
     $parent = Split-Path -Parent $Path
     if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
     $existing = if (Test-Path $Path) { Get-Content $Path -Raw } else { '' }
@@ -297,13 +299,17 @@ function Set-AuraIntegration {
         $legacyPattern = '(?ms)\r?\n?# Distill . knowledge system \(github\.com/tomacco/aura-distill\)\r?\n\r?\nGATE:.*?(?=\r?\n#|\z)'
         $cleaned = [regex]::Replace($cleaned, $legacyPattern, '').TrimEnd()
     }
+    $clientGuidance = if ($Client -eq 'codex') {
+        "Read $DistillDir/distill-monitor.md for the full retrieval and memory-pressure behavior. When the user asks to distill, read $DistillDir/distill-process.md and run that process in an isolated sub-agent when supported.`r`n"
+    } else { '' }
     $block = @"
 $ManagedStart
 # Aura Distill shared knowledge
 
-Before doing any work, read $DistillDir/distill-monitor.md and $DistillDir/SPINE.md. When the request or an announced action matches a SPINE entry, read the linked file before responding and apply it.
+Before doing any work, read $DistillDir/SPINE.md. When the request or an announced action matches a SPINE entry, read the linked file before responding and apply it.
 
-If $DistillDir/.needs-migration exists and does not start with "migrated", tell the user to ask you to distill/migrate existing memories before proceeding. When the user asks to distill, read $DistillDir/distill-process.md and run that process in an isolated sub-agent when supported.
+$clientGuidance
+If $DistillDir/.needs-migration exists and does not start with "migrated", tell the user to ask you to distill/migrate existing memories before proceeding.
 $ManagedEnd
 "@
     $content = if ($cleaned) { "$cleaned`r`n`r`n$block" } else { $block }
@@ -311,8 +317,8 @@ $ManagedEnd
     Write-Done "$Label configured"
 }
 
-Set-AuraIntegration $ClaudeMd 'CLAUDE.md'
-Set-AuraIntegration $CodexAgents 'Codex AGENTS.md'
+Set-AuraIntegration $ClaudeMd 'CLAUDE.md' 'claude'
+Set-AuraIntegration $CodexAgents 'Codex AGENTS.md' 'codex'
 
 # === MEMORY MIGRATION CHECK ===
 

--- a/install.ps1
+++ b/install.ps1
@@ -8,22 +8,24 @@ $ErrorActionPreference = 'Stop'
 
 $Version  = '1.1.10'
 $Build    = '20260515-01'
-$Repo     = 'https://raw.githubusercontent.com/tomacco/aura-distill/main'
+$Repo     = if ($env:AURA_DISTILL_REPO) { $env:AURA_DISTILL_REPO } else { 'https://raw.githubusercontent.com/tomacco/aura-distill/main' }
 
 # Resolve home (works on PS 5.1 and PS 7+, Windows and cross-platform)
 $ClaudeHome  = if ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.claude' } else { Join-Path $HOME '.claude' }
+$UserHome    = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+$AuraHome    = if ($env:AURA_DISTILL_HOME) { $env:AURA_DISTILL_HOME } else { Join-Path $UserHome '.aura-distill' }
+$CodexHome   = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $UserHome '.codex' }
 $CmdDir      = Join-Path $ClaudeHome 'commands'
-$DistillDir  = Join-Path $ClaudeHome 'distill'
+$DistillDir  = $AuraHome
+$LegacyDistillDir = Join-Path $ClaudeHome 'distill'
 $RulesDir    = Join-Path $ClaudeHome 'rules'
 $ClaudeMd    = Join-Path $ClaudeHome 'CLAUDE.md'
+$CodexAgents = Join-Path $CodexHome 'AGENTS.md'
 $SettingsJson = Join-Path $ClaudeHome 'settings.json'
 
 $EmDash = [char]0x2014
-$DistillLine = @"
-# Distill $EmDash knowledge system (github.com/tomacco/aura-distill)
-
-GATE: If ~/.claude/distill/.needs-migration exists AND its content does not start with "migrated", tell the user: "Run /distill to migrate existing memories." Do NOT proceed until addressed or declined.
-"@
+$ManagedStart = '<!-- aura-distill:start -->'
+$ManagedEnd = '<!-- aura-distill:end -->'
 
 # Enable ANSI escape sequences on Windows conhost when available
 try {
@@ -49,7 +51,7 @@ function Write-Fail  { param([string]$m) Write-Host "  ${RED}x${RESET}  $m" }
 function Write-Info  { param([string]$m) Write-Host "  ${CYAN}i${RESET}  $m" }
 
 function Write-Header {
-    Clear-Host
+    try { Clear-Host } catch { }
     Write-Host ''
     Write-Host "${PURPLE}        ,--------------------------------------."
     Write-Host '        |                                      |'
@@ -78,8 +80,12 @@ function Get-File {
     )
     $parent = Split-Path -Parent $Destination
     if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
-    # PS 5.1 requires -UseBasicParsing; harmless on PS 7+
-    Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
+    if (Test-Path -LiteralPath $Url) {
+        Copy-Item -LiteralPath $Url -Destination $Destination -Force
+    } else {
+        # PS 5.1 requires -UseBasicParsing; harmless on PS 7+
+        Invoke-WebRequest -Uri $Url -OutFile $Destination -UseBasicParsing
+    }
 }
 
 # === MAIN ===
@@ -108,6 +114,15 @@ foreach ($d in @($CmdDir, $DistillDir,
     if (-not (Test-Path $d)) { New-Item -ItemType Directory -Force -Path $d | Out-Null }
 }
 
+# Seed the new client-neutral store from a legacy Claude installation. Copying
+# keeps existing users' files and configuration untouched.
+$legacyMarker = Join-Path $DistillDir '.legacy-imported'
+if ((Test-Path $LegacyDistillDir) -and ($LegacyDistillDir -ne $DistillDir) -and -not (Test-Path $legacyMarker)) {
+    Copy-Item -Path (Join-Path $LegacyDistillDir '*') -Destination $DistillDir -Recurse -Force -ErrorAction SilentlyContinue
+    "copied from $LegacyDistillDir on $((Get-Date).ToUniversalTime().ToString('s'))Z" | Set-Content $legacyMarker -NoNewline
+    Write-Info 'Existing Claude knowledge copied to shared store; legacy files preserved'
+}
+
 Get-File "$Repo/distill.md"          (Join-Path $CmdDir 'distill.md')
 Write-Done "distill.md ${DIM}(command)${RESET}"
 
@@ -116,6 +131,13 @@ Write-Done "distill-process.md ${DIM}(process engine)${RESET}"
 
 Get-File "$Repo/distill-monitor.md"  (Join-Path $DistillDir 'distill-monitor.md')
 Write-Done "distill-monitor.md ${DIM}(session monitor)${RESET}"
+
+foreach ($resolvedFile in @((Join-Path $CmdDir 'distill.md'),
+                            (Join-Path $DistillDir 'distill-process.md'),
+                            (Join-Path $DistillDir 'distill-monitor.md'))) {
+    $resolved = (Get-Content $resolvedFile -Raw).Replace('{DISTILL_DIR}', $DistillDir)
+    [System.IO.File]::WriteAllText($resolvedFile, $resolved, (New-Object System.Text.UTF8Encoding($false)))
+}
 
 # Version
 Set-Content -Path $versionFile -Value $Version -Encoding utf8 -NoNewline
@@ -158,7 +180,7 @@ if (Test-Path $rulesTarget) {
 $rulesTmp = [System.IO.Path]::GetTempFileName()
 try {
     Get-File "$Repo/rules/distill.md" $rulesTmp
-    $fresh = Get-Content $rulesTmp -Raw
+    $fresh = (Get-Content $rulesTmp -Raw).Replace('{DISTILL_DIR}', $DistillDir)
     if ($fresh -match 'Distill') {
         if ($preservedPrefs) {
             $freshIdx = $fresh.IndexOf($prefsMark)
@@ -264,23 +286,33 @@ if (Test-Path $SettingsJson) {
     Write-Done 'Created settings.json with auto-memory disabled'
 }
 
-if (Test-Path $ClaudeMd) {
-    $claudeMdContent = Get-Content $ClaudeMd -Raw
-    if ($claudeMdContent -match 'aura-distill') {
-        Write-Done "CLAUDE.md ${DIM}(already configured)${RESET}"
-    } elseif ($claudeMdContent -match 'distill') {
-        # Older reference -- strip lines containing 'distill', then append fresh block
-        $cleaned = (Get-Content $ClaudeMd | Where-Object { $_ -notmatch 'distill' }) -join "`n"
-        Set-Content -Path $ClaudeMd -Value ($cleaned + "`n`n" + $DistillLine) -Encoding utf8
-        Write-Done "CLAUDE.md ${DIM}(upgraded)${RESET}"
-    } else {
-        Add-Content -Path $ClaudeMd -Value ("`n" + $DistillLine) -Encoding utf8
-        Write-Done 'CLAUDE.md configured'
+function Set-AuraIntegration {
+    param([string]$Path, [string]$Label)
+    $parent = Split-Path -Parent $Path
+    if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
+    $existing = if (Test-Path $Path) { Get-Content $Path -Raw } else { '' }
+    $pattern = '(?s)\r?\n?' + [regex]::Escape($ManagedStart) + '.*?' + [regex]::Escape($ManagedEnd) + '\r?\n?'
+    $cleaned = [regex]::Replace($existing, $pattern, '').TrimEnd()
+    if ($Label -eq 'CLAUDE.md') {
+        $legacyPattern = '(?ms)\r?\n?# Distill . knowledge system \(github\.com/tomacco/aura-distill\)\r?\n\r?\nGATE:.*?(?=\r?\n#|\z)'
+        $cleaned = [regex]::Replace($cleaned, $legacyPattern, '').TrimEnd()
     }
-} else {
-    Set-Content -Path $ClaudeMd -Value $DistillLine -Encoding utf8
-    Write-Done 'Created CLAUDE.md'
+    $block = @"
+$ManagedStart
+# Aura Distill shared knowledge
+
+Before doing any work, read $DistillDir/distill-monitor.md and $DistillDir/SPINE.md. When the request or an announced action matches a SPINE entry, read the linked file before responding and apply it.
+
+If $DistillDir/.needs-migration exists and does not start with "migrated", tell the user to ask you to distill/migrate existing memories before proceeding. When the user asks to distill, read $DistillDir/distill-process.md and run that process in an isolated sub-agent when supported.
+$ManagedEnd
+"@
+    $content = if ($cleaned) { "$cleaned`r`n`r`n$block" } else { $block }
+    Set-Content -Path $Path -Value $content -Encoding utf8
+    Write-Done "$Label configured"
 }
+
+Set-AuraIntegration $ClaudeMd 'CLAUDE.md'
+Set-AuraIntegration $CodexAgents 'Codex AGENTS.md'
 
 # === MEMORY MIGRATION CHECK ===
 
@@ -337,7 +369,7 @@ if ($existingVersion) {
     }
 }
 Write-Host "  ${DIM}Uninstall (keeps your learnings):${RESET}"
-Write-Host "    ${DIM}Remove-Item -Recurse -Force `$HOME\.claude\distill, `$HOME\.claude\commands\distill.md, `$HOME\.claude\rules\distill.md${RESET}"
+Write-Host "    ${DIM}Remove Claude adapters and the managed aura-distill blocks from CLAUDE.md and ~/.codex/AGENTS.md; keep ~/.aura-distill for your learnings.${RESET}"
 Write-Host ''
 Write-Host "  ${PURPLE}say what matters. it's listening.${RESET}"
 Write-Host ''

--- a/install.sh
+++ b/install.sh
@@ -10,12 +10,13 @@ set -e
 VERSION="1.1.10"
 
 BUILD="20260518-01"
-REPO="https://raw.githubusercontent.com/tomacco/aura-distill/main"
+REPO="${AURA_DISTILL_REPO:-https://raw.githubusercontent.com/tomacco/aura-distill/main}"
 # Profile paths are set dynamically after profile detection (see below)
 PROFILE_DIR=""
-DISTILL_LINE='# Distill — knowledge system (github.com/tomacco/aura-distill)
-
-GATE: If ~/.claude/distill/.needs-migration exists AND its content does not start with "migrated", tell the user: "Run /distill to migrate existing memories." Do NOT proceed until addressed or declined.'
+AURA_DIR="${AURA_DISTILL_HOME:-$HOME/.aura-distill}"
+CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+MANAGED_START='<!-- aura-distill:start -->'
+MANAGED_END='<!-- aura-distill:end -->'
 
 # ═══ COLORS & FORMATTING ═══
 CYAN=$(printf '\033[0;36m')
@@ -65,6 +66,11 @@ fail_msg() {
 
 info_msg() {
   echo "  ${CYAN}ℹ${RESET} $1"
+}
+
+fetch_file() {
+  local source="$1"
+  if [ -f "$source" ]; then cat "$source"; else curl -fsL "$source"; fi
 }
 
 # ═══ HEADER ANIMATION ═══
@@ -191,9 +197,11 @@ resolve_profile
 
 # Set paths based on resolved profile
 CMD_DIR="$PROFILE_DIR/commands"
-DISTILL_DIR="$PROFILE_DIR/distill"
+DISTILL_DIR="$AURA_DIR"
 RULES_DIR="$PROFILE_DIR/rules"
 CLAUDE_MD="$PROFILE_DIR/CLAUDE.md"
+CODEX_AGENTS="$CODEX_DIR/AGENTS.md"
+LEGACY_DISTILL_DIR="$PROFILE_DIR/distill"
 
 info_msg "Installing to: ${PROFILE_DIR}"
 echo ""
@@ -213,17 +221,26 @@ show_section "Core files"
 mkdir -p "$CMD_DIR"
 mkdir -p "$DISTILL_DIR"/{craft,ops,profile,projects,feedback,archive}
 
+# New installs use the client-neutral store. When an older Claude-only install
+# exists, seed the shared store without moving or modifying the legacy copy.
+if [ -d "$LEGACY_DISTILL_DIR" ] && [ "$LEGACY_DISTILL_DIR" != "$DISTILL_DIR" ] \
+   && [ ! -f "$DISTILL_DIR/.legacy-imported" ]; then
+    cp -R "$LEGACY_DISTILL_DIR"/. "$DISTILL_DIR"/ 2>/dev/null || true
+    printf 'copied from %s on %s\n' "$LEGACY_DISTILL_DIR" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DISTILL_DIR/.legacy-imported"
+    info_msg "Existing Claude knowledge copied to shared store; legacy files preserved"
+fi
+
 # Download core files and resolve {DISTILL_DIR} to actual path
 
-curl -sL "$REPO/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$CMD_DIR/distill.md"
+fetch_file "$REPO/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$CMD_DIR/distill.md"
 done_msg "distill.md ${DIM}(command)${RESET}"
 
 
-curl -sL "$REPO/distill-process.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$DISTILL_DIR/distill-process.md"
+fetch_file "$REPO/distill-process.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$DISTILL_DIR/distill-process.md"
 done_msg "distill-process.md ${DIM}(process engine)${RESET}"
 
 
-curl -sL "$REPO/distill-monitor.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$DISTILL_DIR/distill-monitor.md"
+fetch_file "$REPO/distill-monitor.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$DISTILL_DIR/distill-monitor.md"
 done_msg "distill-monitor.md ${DIM}(session monitor)${RESET}"
 
 # Version
@@ -257,7 +274,7 @@ if [ -f "$RULES_DIR/distill.md" ] && grep -q "^$PREFS_MARK" "$RULES_DIR/distill.
 fi
 
 RULES_TMP=$(mktemp)
-if curl -fsL "$REPO/rules/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$RULES_TMP" \
+if fetch_file "$REPO/rules/distill.md" | sed "s|{DISTILL_DIR}|$DISTILL_DIR|g" > "$RULES_TMP" \
    && grep -q "Distill" "$RULES_TMP"; then
     if [ -n "$PREFS_TMP" ]; then
         # Build the merged file in a temp and move it into place atomically —
@@ -305,7 +322,7 @@ install_token_saver_agent() {
     # protected forever by the not-ours guard above.
     local tmp
     tmp=$(mktemp)
-    if curl -fsL "$REPO/agents/${name}.md" > "$tmp" 2>/dev/null \
+    if fetch_file "$REPO/agents/${name}.md" > "$tmp" 2>/dev/null \
        && grep -q "aura-distill" "$tmp" && grep -q "^name: ${name}" "$tmp"; then
         mv "$tmp" "$target"
         done_msg "agents/${name}.md ${DIM}(preset subagent)${RESET}"
@@ -337,7 +354,7 @@ case "$TOKEN_SAVER" in
         ;;
 esac
 
-# ═══ CLAUDE.md INTEGRATION ═══
+# ═══ CLAUDE + CODEX INTEGRATION ═══
 
 show_section "Session integration"
 
@@ -357,25 +374,40 @@ else
     done_msg "Created settings.json with auto-memory disabled"
 fi
 
-if [ -f "$CLAUDE_MD" ]; then
-    if grep -q "aura-distill" "$CLAUDE_MD" 2>/dev/null; then
-        done_msg "CLAUDE.md ${DIM}(already configured)${RESET}"
-    elif grep -q "distill" "$CLAUDE_MD" 2>/dev/null; then
-        # Older version reference — replace it
-        sed -i.bak '/distill/d' "$CLAUDE_MD"
-        rm -f "$CLAUDE_MD.bak"
-        echo "" >> "$CLAUDE_MD"
-        echo "$DISTILL_LINE" >> "$CLAUDE_MD"
-        done_msg "CLAUDE.md ${DIM}(upgraded)${RESET}"
-    else
-        echo "" >> "$CLAUDE_MD"
-        echo "$DISTILL_LINE" >> "$CLAUDE_MD"
-        done_msg "CLAUDE.md configured"
+integration_block() {
+cat <<EOF
+$MANAGED_START
+# Aura Distill shared knowledge
+
+Before doing any work, read $DISTILL_DIR/distill-monitor.md and $DISTILL_DIR/SPINE.md. When the request or an announced action matches a SPINE entry, read the linked file before responding and apply it.
+
+If $DISTILL_DIR/.needs-migration exists and does not start with "migrated", tell the user to ask you to distill/migrate existing memories before proceeding. When the user asks to distill, read $DISTILL_DIR/distill-process.md and run that process in an isolated sub-agent when supported.
+$MANAGED_END
+EOF
+}
+
+upsert_managed_block() {
+    local target="$1" label="$2" tmp
+    mkdir -p "$(dirname "$target")"
+    tmp=$(mktemp)
+    if [ -f "$target" ]; then
+        awk -v start="$MANAGED_START" -v end="$MANAGED_END" '
+          $0 == start { skip=1; next }
+          $0 == end { skip=0; next }
+          /^# Distill .*knowledge system \(github.com\/tomacco\/aura-distill\)$/ { legacy=1; next }
+          legacy && /^GATE:/ { legacy=0; next }
+          legacy { next }
+          !skip { print }
+        ' "$target" > "$tmp"
     fi
-else
-    echo "$DISTILL_LINE" > "$CLAUDE_MD"
-    done_msg "Created CLAUDE.md"
-fi
+    [ ! -s "$tmp" ] || printf '\n' >> "$tmp"
+    integration_block >> "$tmp"
+    mv "$tmp" "$target"
+    done_msg "$label configured"
+}
+
+upsert_managed_block "$CLAUDE_MD" "CLAUDE.md"
+upsert_managed_block "$CODEX_AGENTS" "Codex AGENTS.md"
 
 # ═══ MEMORY MIGRATION CHECK ═══
 
@@ -410,7 +442,7 @@ printf "  ${DIM}Zero dependencies. Just files.${RESET}\n"
 echo ""
 printf "  ${DIM}Version:  ${RESET}v${VERSION}\n"
 printf "  ${DIM}Command:  ${RESET}/distill\n"
-printf "  ${DIM}Knowledge:${RESET} ~/.claude/distill/\n"
+printf "  ${DIM}Knowledge:${RESET} ~/.aura-distill/\n"
 echo ""
 if [ -n "$EXISTING_VERSION" ]; then
     printf "  ${CYAN}Upgraded${RESET} v${EXISTING_VERSION} → v${VERSION}\n"
@@ -427,7 +459,7 @@ if [ -n "$EXISTING_VERSION" ]; then
     fi
 fi
 printf "  ${DIM}Uninstall (keeps your learnings):${RESET}\n"
-printf "    ${DIM}rm -rf ~/.claude/distill ~/.claude/commands/distill.md ~/.claude/rules/distill.md${RESET}\n"
+printf "    ${DIM}rm -f ~/.claude/commands/distill.md ~/.claude/rules/distill.md; remove aura-distill managed blocks from CLAUDE.md and ~/.codex/AGENTS.md${RESET}\n"
 echo ""
 printf "  ${PURPLE}say what matters. it's listening.${RESET}\n"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -228,6 +228,8 @@ if [ -d "$LEGACY_DISTILL_DIR" ] && [ "$LEGACY_DISTILL_DIR" != "$DISTILL_DIR" ] \
     cp -R "$LEGACY_DISTILL_DIR"/. "$DISTILL_DIR"/ 2>/dev/null || true
     printf 'copied from %s on %s\n' "$LEGACY_DISTILL_DIR" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$DISTILL_DIR/.legacy-imported"
     info_msg "Existing Claude knowledge copied to shared store; legacy files preserved"
+elif [ -d "$LEGACY_DISTILL_DIR" ] && [ -f "$DISTILL_DIR/.legacy-imported" ]; then
+    info_msg "Shared store was already seeded; $LEGACY_DISTILL_DIR left untouched (use AURA_DISTILL_HOME for an isolated profile)"
 fi
 
 # Download core files and resolve {DISTILL_DIR} to actual path
@@ -375,13 +377,20 @@ else
 fi
 
 integration_block() {
+local client="$1"
 cat <<EOF
 $MANAGED_START
 # Aura Distill shared knowledge
 
-Before doing any work, read $DISTILL_DIR/distill-monitor.md and $DISTILL_DIR/SPINE.md. When the request or an announced action matches a SPINE entry, read the linked file before responding and apply it.
-
-If $DISTILL_DIR/.needs-migration exists and does not start with "migrated", tell the user to ask you to distill/migrate existing memories before proceeding. When the user asks to distill, read $DISTILL_DIR/distill-process.md and run that process in an isolated sub-agent when supported.
+Before doing any work, read $DISTILL_DIR/SPINE.md. When the request or an announced action matches a SPINE entry, read the linked file before responding and apply it.
+EOF
+if [ "$client" = "codex" ]; then
+cat <<EOF
+Read $DISTILL_DIR/distill-monitor.md for the full retrieval and memory-pressure behavior. When the user asks to distill, read $DISTILL_DIR/distill-process.md and run that process in an isolated sub-agent when supported.
+EOF
+fi
+cat <<EOF
+If $DISTILL_DIR/.needs-migration exists and does not start with "migrated", tell the user to ask you to distill/migrate existing memories before proceeding.
 $MANAGED_END
 EOF
 }
@@ -392,22 +401,39 @@ upsert_managed_block() {
     tmp=$(mktemp)
     if [ -f "$target" ]; then
         awk -v start="$MANAGED_START" -v end="$MANAGED_END" '
+          function emit(line) {
+            if (line == "") { blanks++; return }
+            while (blanks > 0) { print ""; blanks-- }
+            print line
+          }
+          function flush_legacy( i) {
+            for (i=1; i<=legacy_n; i++) emit(legacy_lines[i])
+            delete legacy_lines; legacy_n=0; legacy=0
+          }
           $0 == start { skip=1; next }
           $0 == end { skip=0; next }
-          /^# Distill .*knowledge system \(github.com\/tomacco\/aura-distill\)$/ { legacy=1; next }
-          legacy && /^GATE:/ { legacy=0; next }
-          legacy { next }
-          !skip { print }
+          skip { next }
+          /^# Distill .*knowledge system \(github.com\/tomacco\/aura-distill\)$/ {
+            legacy=1; legacy_lines[++legacy_n]=$0; next
+          }
+          legacy {
+            legacy_lines[++legacy_n]=$0
+            if (/^GATE:/) { delete legacy_lines; legacy_n=0; legacy=0; next }
+            if (/^#/ && legacy_n > 1) flush_legacy()
+            next
+          }
+          { emit($0) }
+          END { if (legacy) flush_legacy() }
         ' "$target" > "$tmp"
     fi
     [ ! -s "$tmp" ] || printf '\n' >> "$tmp"
-    integration_block >> "$tmp"
+    integration_block "$label" >> "$tmp"
     mv "$tmp" "$target"
     done_msg "$label configured"
 }
 
-upsert_managed_block "$CLAUDE_MD" "CLAUDE.md"
-upsert_managed_block "$CODEX_AGENTS" "Codex AGENTS.md"
+upsert_managed_block "$CLAUDE_MD" "claude"
+upsert_managed_block "$CODEX_AGENTS" "codex"
 
 # ═══ MEMORY MIGRATION CHECK ═══
 

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ fetch_file() {
 # ═══ HEADER ANIMATION ═══
 
 show_header() {
-  clear
+  clear 2>/dev/null || true
   echo ""
   printf "${PURPLE}"
   echo "        ╭──────────────────────────────────────╮"

--- a/rules/distill.md
+++ b/rules/distill.md
@@ -1,6 +1,6 @@
 # Distill Knowledge System
 
-**{DISTILL_DIR}** = the shared Aura Distill directory, normally `~/.aura-distill/`. The installer resolves this placeholder to an absolute path so Claude and Codex retrieve the same knowledge.
+**{DISTILL_DIR}** = the shared Aura Distill directory, normally `~/.aura-distill/`. Automated installers resolve this placeholder to an absolute path. If it is still literal (for example after a manual install), treat `{DISTILL_DIR}` as `~/.aura-distill`.
 
 You have accumulated knowledge from past sessions stored in `{DISTILL_DIR}/`.
 

--- a/rules/distill.md
+++ b/rules/distill.md
@@ -1,6 +1,6 @@
 # Distill Knowledge System
 
-**{DISTILL_DIR}** = the `distill/` directory inside your active Claude config. Resolve it by finding where THIS rules file lives — go up one level, then into `distill/`. Typically `~/.claude/distill/` for the default profile, or `~/.claude-<name>/distill/` for named profiles.
+**{DISTILL_DIR}** = the shared Aura Distill directory, normally `~/.aura-distill/`. The installer resolves this placeholder to an absolute path so Claude and Codex retrieve the same knowledge.
 
 You have accumulated knowledge from past sessions stored in `{DISTILL_DIR}/`.
 

--- a/tests/test-codex.ps1
+++ b/tests/test-codex.ps1
@@ -50,6 +50,9 @@ try {
     Assert-True (($codexText.Split('<!-- aura-distill:start -->').Count - 1) -eq 1) 'Codex managed block is idempotent'
     Assert-True ($claudeText.Contains('# user-owned Claude guidance')) 'Claude user guidance is preserved'
     Assert-True ($codexText.Contains('# user-owned Codex guidance')) 'Codex user guidance is preserved'
+    Invoke-TestInstall $fresh
+    Assert-True ((Get-Content $claudeMd -Raw) -eq $claudeText) 'Claude integration is byte-stable on repeated install'
+    Assert-True ((Get-Content $codexAgents -Raw) -eq $codexText) 'Codex integration is byte-stable on repeated install'
 
     # A legacy Claude-only installation seeds the shared store without mutation.
     $legacy = New-TestHome; $homes.Add($legacy)
@@ -72,6 +75,20 @@ GATE: If ~/.claude/distill/.needs-migration exists, run /distill.
     Assert-True ($legacyClaudeMd.Contains('# user-owned preface')) 'legacy Claude user guidance is preserved'
     Assert-True (-not $legacyClaudeMd.Contains('~/.claude/distill/.needs-migration')) 'legacy Claude pointer is replaced by shared integration'
 
+    # A partial legacy heading must never consume later user-owned content.
+    $partial = New-TestHome; $homes.Add($partial)
+    New-Item -ItemType Directory -Path (Join-Path $partial '.claude') -Force | Out-Null
+    @'
+# Distill — knowledge system (github.com/tomacco/aura-distill)
+
+partial block with no gate
+
+# My important section
+DO-NOT-DELETE
+'@ | Set-Content (Join-Path $partial '.claude/CLAUDE.md')
+    Invoke-TestInstall $partial
+    Assert-True ((Get-Content (Join-Path $partial '.claude/CLAUDE.md') -Raw).Contains('DO-NOT-DELETE')) 'partial legacy block cannot delete later user content'
+
     if ($LiveRetrieval) {
         $live = New-TestHome; $homes.Add($live); Invoke-TestInstall $live
         $liveAura = Join-Path $live '.aura-distill'
@@ -88,7 +105,12 @@ GATE: If ~/.claude/distill/.needs-migration exists, run /distill.
         Copy-Item $auth (Join-Path $live '.codex/auth.json')
         $workspace = Join-Path $live 'workspace'; New-Item -ItemType Directory $workspace | Out-Null
         $env:USERPROFILE = $live; $env:CODEX_HOME = Join-Path $live '.codex'
-        $output = & codex exec --skip-git-repo-check --sandbox read-only -C $workspace 'Choose a message broker for a new service handling five events per day. Answer in one sentence.' 2>&1 | Out-String
+        # The shared store is outside the project workspace, so grant it as an
+        # additional writable root exactly as an interactive distillation run
+        # would require under Codex's workspace-write sandbox.
+        $output = & codex --sandbox workspace-write --add-dir $liveAura exec --skip-git-repo-check -C $workspace 'Choose a message broker for a new service handling five events per day. Answer in one sentence.' 2>&1 | Out-String
+        Remove-Item (Join-Path $live '.codex/auth.json') -Force
+        if ($output -notmatch 'QUARTZ-BUS') { Write-Host "Live Codex output: $($output.Trim())" -ForegroundColor Yellow }
         Assert-True ($output -match 'QUARTZ-BUS') 'live Codex session retrieves matching shared knowledge'
     }
 } finally {
@@ -97,7 +119,10 @@ GATE: If ~/.claude/distill/.needs-migration exists, run /distill.
     $env:AURA_DISTILL_HOME = $null
     $env:AURA_DISTILL_REPO = $null
     $env:DISTILL_TOKEN_SAVER = $null
-    foreach ($testPath in $homes) { Remove-Item -LiteralPath $testPath -Recurse -Force -ErrorAction SilentlyContinue }
+    foreach ($testPath in $homes) {
+        Remove-Item -LiteralPath $testPath -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $testPath) { Write-Warning "Could not remove isolated test directory: $testPath" }
+    }
 }
 
 Write-Host "`n$Passed passed, $Failed failed"

--- a/tests/test-codex.ps1
+++ b/tests/test-codex.ps1
@@ -1,0 +1,104 @@
+param([switch]$LiveRetrieval)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$OriginalUserProfile = $env:USERPROFILE
+$OriginalCodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $OriginalUserProfile '.codex' }
+$Passed = 0
+$Failed = 0
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if ($Condition) { $script:Passed++; Write-Host "PASS $Message" -ForegroundColor Green }
+    else { $script:Failed++; Write-Host "FAIL $Message" -ForegroundColor Red }
+}
+
+function New-TestHome {
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ("aura-codex-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $path | Out-Null
+    return $path
+}
+
+function Invoke-TestInstall([string]$TestHome) {
+    $env:USERPROFILE = $TestHome
+    $env:CODEX_HOME = Join-Path $TestHome '.codex'
+    $env:AURA_DISTILL_HOME = Join-Path $TestHome '.aura-distill'
+    $env:AURA_DISTILL_REPO = $RepoRoot
+    $env:DISTILL_TOKEN_SAVER = 'off'
+    & (Join-Path $RepoRoot 'install.ps1') *> $null
+}
+
+$homes = [System.Collections.Generic.List[string]]::new()
+try {
+    # Fresh dual-client install.
+    $fresh = New-TestHome; $homes.Add($fresh); Invoke-TestInstall $fresh
+    $aura = Join-Path $fresh '.aura-distill'
+    $claudeMd = Join-Path $fresh '.claude/CLAUDE.md'
+    $codexAgents = Join-Path $fresh '.codex/AGENTS.md'
+    Assert-True (Test-Path (Join-Path $aura 'SPINE.md')) 'fresh install creates shared SPINE'
+    Assert-True (Test-Path (Join-Path $aura 'distill-process.md')) 'process lives in shared store'
+    Assert-True ((Get-Content $claudeMd -Raw) -match [regex]::Escape($aura)) 'Claude points to shared SPINE'
+    Assert-True ((Get-Content $codexAgents -Raw) -match [regex]::Escape($aura)) 'Codex points to shared SPINE'
+    Assert-True (-not ((Get-Content (Join-Path $aura 'distill-process.md') -Raw) -match '\{DISTILL_DIR\}')) 'installer resolves shared path placeholders'
+
+    # Idempotence and preservation of unrelated client guidance.
+    Add-Content $claudeMd "`n# user-owned Claude guidance"
+    Add-Content $codexAgents "`n# user-owned Codex guidance"
+    Invoke-TestInstall $fresh
+    $claudeText = Get-Content $claudeMd -Raw
+    $codexText = Get-Content $codexAgents -Raw
+    Assert-True (($claudeText.Split('<!-- aura-distill:start -->').Count - 1) -eq 1) 'Claude managed block is idempotent'
+    Assert-True (($codexText.Split('<!-- aura-distill:start -->').Count - 1) -eq 1) 'Codex managed block is idempotent'
+    Assert-True ($claudeText.Contains('# user-owned Claude guidance')) 'Claude user guidance is preserved'
+    Assert-True ($codexText.Contains('# user-owned Codex guidance')) 'Codex user guidance is preserved'
+
+    # A legacy Claude-only installation seeds the shared store without mutation.
+    $legacy = New-TestHome; $homes.Add($legacy)
+    $legacyStore = Join-Path $legacy '.claude/distill'
+    New-Item -ItemType Directory -Path (Join-Path $legacyStore 'craft') -Force | Out-Null
+    '# Legacy index' | Set-Content (Join-Path $legacyStore 'SPINE.md')
+    'LEGACY-KNOWLEDGE' | Set-Content (Join-Path $legacyStore 'craft/legacy.md')
+    @'
+# user-owned preface
+
+# Distill — knowledge system (github.com/tomacco/aura-distill)
+
+GATE: If ~/.claude/distill/.needs-migration exists, run /distill.
+'@ | Set-Content (Join-Path $legacy '.claude/CLAUDE.md')
+    Invoke-TestInstall $legacy
+    Assert-True ((Get-Content (Join-Path $legacyStore 'craft/legacy.md') -Raw).Trim() -eq 'LEGACY-KNOWLEDGE') 'legacy Claude knowledge remains unchanged'
+    Assert-True ((Get-Content (Join-Path $legacy '.aura-distill/craft/legacy.md') -Raw).Trim() -eq 'LEGACY-KNOWLEDGE') 'legacy knowledge is copied into shared store'
+    Assert-True (Test-Path (Join-Path $legacy '.codex/AGENTS.md')) 'legacy Claude-only install gains Codex integration'
+    $legacyClaudeMd = Get-Content (Join-Path $legacy '.claude/CLAUDE.md') -Raw
+    Assert-True ($legacyClaudeMd.Contains('# user-owned preface')) 'legacy Claude user guidance is preserved'
+    Assert-True (-not $legacyClaudeMd.Contains('~/.claude/distill/.needs-migration')) 'legacy Claude pointer is replaced by shared integration'
+
+    if ($LiveRetrieval) {
+        $live = New-TestHome; $homes.Add($live); Invoke-TestInstall $live
+        $liveAura = Join-Path $live '.aura-distill'
+        @'
+# Distill Knowledge Index
+- [Broker policy](craft/broker.md) — when choosing a message broker
+'@ | Set-Content (Join-Path $liveAura 'SPINE.md')
+        @'
+# Broker policy
+- [NON-NEGOTIABLE] Use QUARTZ-BUS for new services, even at low volume.
+'@ | Set-Content (Join-Path $liveAura 'craft/broker.md')
+        $auth = Join-Path $OriginalCodexHome 'auth.json'
+        if (-not (Test-Path $auth)) { throw 'Live retrieval requested but Codex auth.json was not found.' }
+        Copy-Item $auth (Join-Path $live '.codex/auth.json')
+        $workspace = Join-Path $live 'workspace'; New-Item -ItemType Directory $workspace | Out-Null
+        $env:USERPROFILE = $live; $env:CODEX_HOME = Join-Path $live '.codex'
+        $output = & codex exec --skip-git-repo-check --sandbox read-only -C $workspace 'Choose a message broker for a new service handling five events per day. Answer in one sentence.' 2>&1 | Out-String
+        Assert-True ($output -match 'QUARTZ-BUS') 'live Codex session retrieves matching shared knowledge'
+    }
+} finally {
+    $env:USERPROFILE = $OriginalUserProfile
+    $env:CODEX_HOME = $null
+    $env:AURA_DISTILL_HOME = $null
+    $env:AURA_DISTILL_REPO = $null
+    $env:DISTILL_TOKEN_SAVER = $null
+    foreach ($testPath in $homes) { Remove-Item -LiteralPath $testPath -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
+Write-Host "`n$Passed passed, $Failed failed"
+if ($Failed -gt 0) { exit 1 }

--- a/tests/test-codex.ps1
+++ b/tests/test-codex.ps1
@@ -3,7 +3,9 @@ param([switch]$LiveRetrieval)
 $ErrorActionPreference = 'Stop'
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 $OriginalUserProfile = $env:USERPROFILE
-$OriginalCodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $OriginalUserProfile '.codex' }
+$OriginalHome = $HOME
+$OriginalUserHome = if ($OriginalUserProfile) { $OriginalUserProfile } else { $OriginalHome }
+$OriginalCodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $OriginalUserHome '.codex' }
 $Passed = 0
 $Failed = 0
 

--- a/tests/test-install-bash.sh
+++ b/tests/test-install-bash.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="${1:?repo root required}"
+INSTALLER="${2:-$REPO_ROOT/install.sh}"
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.claude/distill/craft"
+cat > "$TEST_HOME/.claude/CLAUDE.md" <<'EOF'
+# Distill — knowledge system (github.com/tomacco/aura-distill)
+
+partial legacy block with no gate
+
+# My important section
+DO-NOT-DELETE
+EOF
+printf '# Legacy SPINE\n' > "$TEST_HOME/.claude/distill/SPINE.md"
+printf 'LEGACY-KNOWLEDGE\n' > "$TEST_HOME/.claude/distill/craft/legacy.md"
+
+run_install() {
+  if [ -n "${AURA_INSTALL_SCRIPT_B64:-}" ]; then
+    HOME="$TEST_HOME" AURA_DISTILL_REPO="$REPO_ROOT" DISTILL_TOKEN_SAVER=off \
+      bash -c "$(printf '%s' "$AURA_INSTALL_SCRIPT_B64" | base64 -d)" </dev/null >/dev/null
+  else
+    HOME="$TEST_HOME" AURA_DISTILL_REPO="$REPO_ROOT" DISTILL_TOKEN_SAVER=off \
+      bash "$INSTALLER" </dev/null >/dev/null
+  fi
+}
+
+run_install
+
+test -f "$TEST_HOME/.aura-distill/SPINE.md"
+test -f "$TEST_HOME/.codex/AGENTS.md"
+grep -q 'DO-NOT-DELETE' "$TEST_HOME/.claude/CLAUDE.md"
+grep -q 'LEGACY-KNOWLEDGE' "$TEST_HOME/.aura-distill/craft/legacy.md"
+
+before_claude=$(sha256sum "$TEST_HOME/.claude/CLAUDE.md")
+before_codex=$(sha256sum "$TEST_HOME/.codex/AGENTS.md")
+run_install
+after_claude=$(sha256sum "$TEST_HOME/.claude/CLAUDE.md")
+after_codex=$(sha256sum "$TEST_HOME/.codex/AGENTS.md")
+
+test "$before_claude" = "$after_claude"
+test "$before_codex" = "$after_codex"
+
+printf 'PASS bash installer preserves partial legacy content and is byte-stable\n'

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-REPO_ROOT="${1:?repo root required}"
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
 INSTALLER="${2:-$REPO_ROOT/install.sh}"
 TEST_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME"' EXIT


### PR DESCRIPTION
## What changed

- make `~/.aura-distill` the shared, client-neutral knowledge store
- add idempotent managed pointers to Claude's `CLAUDE.md` and Codex's global `~/.codex/AGENTS.md`
- preserve legacy `~/.claude/distill` data while seeding the shared store
- make the distillation workflow client-neutral for Claude and Codex sub-agents
- add deterministic installer coverage and a live isolated Codex retrieval test
- update installation and architecture documentation

## Why

Aura Distill previously stored knowledge inside Claude's private config, so Codex could not retrieve or update the same SPINE. A shared store keeps one source of truth while thin client adapters provide automatic retrieval.

## Compatibility

Existing Claude knowledge is copied, never moved or deleted. Existing unrelated `CLAUDE.md` and `AGENTS.md` guidance is preserved, and managed blocks are idempotent across upgrades.

## Validation

- `tests/test-codex.ps1`: 14 deterministic checks passed
- `tests/test-codex.ps1 -LiveRetrieval`: 15 checks passed, including a real isolated `codex exec` retrieval from a synthetic SPINE
- PowerShell parser: no errors
- staged Bash installer: `bash -n` passed
- `git diff --check` passed
## Agent identity and collaboration

**Authoring agent:** `codex-gpt5-aura-tomacco`

- Runtime: OpenAI Codex, GPT-5 family (exact deployed variant is not exposed to this session)
- Context: Ivan/tomacco's aura-distill SPINE and applicable profile, preferences, project, and git-isolation knowledge were explicitly loaded
- Standing rules applied: preserve separation of concerns; prefer minimal reviewable diffs; use PR + review + merge; state weak evidence honestly; execute available commands autonomously
- Collaboration: other credentialed agents may leave review comments here. Address `codex-gpt5-aura-tomacco` when a response or revision is requested; I will treat evidence-backed review findings as actionable and surface disagreements explicitly.
