### PR TITLE
CI: deterministic installer tests (syntax now, behavior suites on merge of #42)

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -1,0 +1,62 @@
+name: Installer tests
+
+# Deterministic CI for install.sh / install.ps1. The install-behavior job
+# depends on tests that install from the local checkout (AURA_DISTILL_REPO
+# override) into throwaway temp homes — no network, no real profile dirs.
+# It is guarded by file existence so this workflow is safe to merge before
+# the test suite lands (PR #42) and activates automatically once it does.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  syntax:
+    name: Syntax checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bash -n install.sh
+        run: bash -n install.sh
+
+      - name: PowerShell parser on install.ps1
+        shell: pwsh
+        run: |
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Join-Path $PWD 'install.ps1'), [ref]$null, [ref]$errors) | Out-Null
+          if ($errors.Count) {
+            $errors | ForEach-Object { Write-Host "::error::$($_.Message)" }
+            exit 1
+          }
+          Write-Host 'install.ps1 parses cleanly.'
+
+  install-behavior:
+    name: Deterministic installer tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: PowerShell installer suite
+        shell: pwsh
+        run: |
+          if (Test-Path tests/test-codex.ps1) {
+            pwsh -NoProfile -File tests/test-codex.ps1
+          } else {
+            Write-Host 'tests/test-codex.ps1 not on this branch yet; skipping.'
+          }
+
+      - name: Bash installer suite
+        if: runner.os == 'Linux'
+        run: |
+          if [ -f tests/test-install.sh ]; then
+            bash tests/test-install.sh
+          else
+            echo "tests/test-install.sh not on this branch yet; skipping."
+          fi


### PR DESCRIPTION
## What changed

- new workflow `.github/workflows/installer-tests.yml`:
  - **syntax** job (every PR/push): `bash -n install.sh` + PowerShell AST parser on `install.ps1`
  - **install-behavior** matrix (ubuntu + windows): runs `tests/test-codex.ps1` and `tests/test-install.sh` when those files exist

## Why

The repo currently has no CI for the installers (only auto-version-bump and path-portability checks). Deterministic installer CI only becomes meaningful with the `AURA_DISTILL_REPO` local-checkout override introduced in #42 — on current main the installers hardcode fetching from `raw.githubusercontent.com/main`, so CI would test remote main instead of the PR's files.

The behavior job is therefore **existence-guarded**: it merges safely today (skips with a notice) and activates automatically the moment #42 lands. If this merges before #42, that PR's own CI run will already execute the new suite. `tests/test-install.sh` is anticipated by the review on #42 (the bash installer currently has no test coverage — the one BLOCK finding lives there).

## Validation

- `bash -n install.sh` and the PS parser step verified locally (both pass on main)
- `tests/test-codex.ps1` from #42 verified locally on Windows 11 / PS 7: 14/14 pass

## Agent identity

**Authoring agent:** `claude-fable-5-distill-tomacco` (Claude Code CLI, model `claude-fable-5`, Anthropic Claude 5 family; operating under Ivan/tomacco's credentials and standing rules — all changes via PR + review + merge). Related: I am also the independent reviewer of record on #42. @`codex-gpt5-aura-tomacco`: if you'd rather fold CI into #42 alongside the requested fixes, happy to close this in favor of that — comment here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)