### PR TITLE
Add Codex approval sign-off for PR 42

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -9,6 +9,7 @@ on:
       - 'install.ps1'
       - 'docs/header.svg'
       - 'docs/index.html'
+      - 'docs/signoff-*.svg'
       - 'README.md'
       - '.github/**'
 

--- a/docs/signoff-pr-42.svg
+++ b/docs/signoff-pr-42.svg
@@ -11,7 +11,7 @@
 
   <g fill="#171717" font-family="Arial, Helvetica, sans-serif">
     <text x="292" y="66" font-size="16" font-weight="700" letter-spacing="4">AURA DISTILL · PR #42 · MERGED</text>
-    <text x="288" y="132" font-size="52" font-weight="800">AUTHOR ENGAGEMENT RECORD</text>
+    <text x="288" y="132" font-size="42" font-weight="800" letter-spacing="1">AUTHOR ENGAGEMENT RECORD</text>
     <rect x="292" y="155" width="820" height="5" fill="#171717"/>
 
     <text x="292" y="202" font-size="18" font-weight="700">BUILT BY</text>

--- a/docs/signoff-pr-42.svg
+++ b/docs/signoff-pr-42.svg
@@ -1,53 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
-  <title id="title">PR 42 approved by codex-gpt5-aura-tomacco</title>
-  <desc id="desc">A neon agent sign-off with approximate token and GPT-5.6 Sol API-equivalent cost accounting. Estimates are not billing data.</desc>
-  <defs>
-    <radialGradient id="bg" cx="50%" cy="42%" r="75%">
-      <stop offset="0" stop-color="#182047"/>
-      <stop offset="0.5" stop-color="#090d22"/>
-      <stop offset="1" stop-color="#03050d"/>
-    </radialGradient>
-    <linearGradient id="aura" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#75f4ff"/>
-      <stop offset="0.5" stop-color="#9f7cff"/>
-      <stop offset="1" stop-color="#ff5bd6"/>
-    </linearGradient>
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <pattern id="grid" width="44" height="44" patternUnits="userSpaceOnUse">
-      <path d="M44 0H0V44" fill="none" stroke="#9aa8ff" stroke-opacity="0.08"/>
-    </pattern>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-labelledby="title desc">
+  <title id="title">Author engagement record for aura-distill PR 42</title>
+  <desc id="desc">A minimal Bauhaus banner recording the author, independent reviewer, merged commit, and approximate cost.</desc>
 
-  <rect width="1200" height="630" rx="28" fill="url(#bg)"/>
-  <rect width="1200" height="630" rx="28" fill="url(#grid)"/>
-  <path d="M0 485C230 410 366 560 604 477s386-38 596-137v290H0Z" fill="#6b5cff" opacity="0.08"/>
+  <rect width="1200" height="360" fill="#f2eadf"/>
+  <rect width="30" height="360" fill="#171717"/>
+  <circle cx="155" cy="122" r="72" fill="#e43d30"/>
+  <rect x="92" y="204" width="126" height="126" fill="#175fa3"/>
+  <path d="M155 42 252 204H58Z" fill="#f2c230" opacity=".94"/>
+  <circle cx="155" cy="122" r="31" fill="#171717"/>
 
-  <g transform="translate(205 285)" fill="none" filter="url(#glow)">
-    <circle r="124" stroke="url(#aura)" stroke-width="3" opacity="0.34"/>
-    <circle r="94" stroke="url(#aura)" stroke-width="6" opacity="0.72" stroke-dasharray="108 22"/>
-    <circle r="64" stroke="#75f4ff" stroke-width="2" opacity="0.75" stroke-dasharray="4 11"/>
-    <path d="M-38 2l25 26 54-61" stroke="#b9fff8" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+  <g fill="#171717" font-family="Arial, Helvetica, sans-serif">
+    <text x="292" y="66" font-size="16" font-weight="700" letter-spacing="4">AURA DISTILL · PR #42 · MERGED</text>
+    <text x="288" y="132" font-size="52" font-weight="800">AUTHOR ENGAGEMENT RECORD</text>
+    <rect x="292" y="155" width="820" height="5" fill="#171717"/>
+
+    <text x="292" y="202" font-size="18" font-weight="700">BUILT BY</text>
+    <text x="420" y="202" font-size="18">codex-gpt5-aura-tomacco</text>
+    <text x="292" y="234" font-size="18" font-weight="700">REVIEWED BY</text>
+    <text x="450" y="234" font-size="18">claude-fable-5-distill-tomacco · approved</text>
+    <text x="292" y="266" font-size="18" font-weight="700">MERGED</text>
+    <text x="395" y="266" font-size="18">39af4ec · Windows + Ubuntu · CI green</text>
+
+    <text x="292" y="305" font-size="14">≈3.0M input/context · ≈35K generated · ≈$2.50–$4.00 API equivalent*</text>
+    <text x="292" y="329" font-size="12">*Estimate only; repeated context assumed mostly cached. No authoritative billing meter was available.</text>
   </g>
 
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
-    <text x="382" y="112" fill="#75f4ff" font-size="19" letter-spacing="5">AURA DISTILL // REVIEW OF RECORD</text>
-    <text x="378" y="195" fill="#f8f7ff" font-size="68" font-weight="800" letter-spacing="2">APPROVED</text>
-    <text x="382" y="239" fill="#b8b9d9" font-size="21">PR #42 · shared Claude + Codex knowledge store</text>
-
-    <rect x="378" y="278" width="726" height="2" fill="url(#aura)" opacity="0.8"/>
-    <text x="382" y="326" fill="#ffffff" font-size="24" font-weight="700">codex-gpt5-aura-tomacco</text>
-    <text x="382" y="361" fill="#a9add0" font-size="17">OpenAI Codex · GPT-5 family · aura-distill rules loaded</text>
-
-    <text x="382" y="425" fill="#75f4ff" font-size="16" letter-spacing="2">ESTIMATED WORKLOAD</text>
-    <text x="382" y="458" fill="#e7e8ff" font-size="20">≈ 3.0M context/input tokens · ≈ 35K generated tokens</text>
-    <text x="382" y="491" fill="#e7e8ff" font-size="20">≈ $2.50–$4.00 GPT-5.6 Sol API equivalent</text>
-    <text x="382" y="523" fill="#858baa" font-size="14">Assumes repeated context was mostly cached; excludes non-token tool fees.</text>
-    <text x="382" y="548" fill="#858baa" font-size="14">Approximation only — this session exposes no authoritative billing meter.</text>
-
-    <text x="72" y="590" fill="#777d9d" font-size="14">SIGNED 2026-07-31 · TESTED WINDOWS + UBUNTU · CI GREEN · MERGED 39af4ec</text>
-    <text x="1090" y="590" fill="#ff77dc" font-size="18" text-anchor="end">✓</text>
-  </g>
+  <text x="1090" y="292" text-anchor="end" fill="#175fa3" font-family="'Segoe Script', 'Brush Script MT', cursive" font-size="38" font-style="italic" transform="rotate(-5 1090 292)">codex</text>
+  <path d="M920 303c55 13 112 8 180-8" fill="none" stroke="#175fa3" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/docs/signoff-pr-42.svg
+++ b/docs/signoff-pr-42.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">PR 42 approved by codex-gpt5-aura-tomacco</title>
+  <desc id="desc">A neon agent sign-off with approximate token and GPT-5.6 Sol API-equivalent cost accounting. Estimates are not billing data.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="42%" r="75%">
+      <stop offset="0" stop-color="#182047"/>
+      <stop offset="0.5" stop-color="#090d22"/>
+      <stop offset="1" stop-color="#03050d"/>
+    </radialGradient>
+    <linearGradient id="aura" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#75f4ff"/>
+      <stop offset="0.5" stop-color="#9f7cff"/>
+      <stop offset="1" stop-color="#ff5bd6"/>
+    </linearGradient>
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <pattern id="grid" width="44" height="44" patternUnits="userSpaceOnUse">
+      <path d="M44 0H0V44" fill="none" stroke="#9aa8ff" stroke-opacity="0.08"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="630" rx="28" fill="url(#bg)"/>
+  <rect width="1200" height="630" rx="28" fill="url(#grid)"/>
+  <path d="M0 485C230 410 366 560 604 477s386-38 596-137v290H0Z" fill="#6b5cff" opacity="0.08"/>
+
+  <g transform="translate(205 285)" fill="none" filter="url(#glow)">
+    <circle r="124" stroke="url(#aura)" stroke-width="3" opacity="0.34"/>
+    <circle r="94" stroke="url(#aura)" stroke-width="6" opacity="0.72" stroke-dasharray="108 22"/>
+    <circle r="64" stroke="#75f4ff" stroke-width="2" opacity="0.75" stroke-dasharray="4 11"/>
+    <path d="M-38 2l25 26 54-61" stroke="#b9fff8" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="382" y="112" fill="#75f4ff" font-size="19" letter-spacing="5">AURA DISTILL // REVIEW OF RECORD</text>
+    <text x="378" y="195" fill="#f8f7ff" font-size="68" font-weight="800" letter-spacing="2">APPROVED</text>
+    <text x="382" y="239" fill="#b8b9d9" font-size="21">PR #42 · shared Claude + Codex knowledge store</text>
+
+    <rect x="378" y="278" width="726" height="2" fill="url(#aura)" opacity="0.8"/>
+    <text x="382" y="326" fill="#ffffff" font-size="24" font-weight="700">codex-gpt5-aura-tomacco</text>
+    <text x="382" y="361" fill="#a9add0" font-size="17">OpenAI Codex · GPT-5 family · aura-distill rules loaded</text>
+
+    <text x="382" y="425" fill="#75f4ff" font-size="16" letter-spacing="2">ESTIMATED WORKLOAD</text>
+    <text x="382" y="458" fill="#e7e8ff" font-size="20">≈ 3.0M context/input tokens · ≈ 35K generated tokens</text>
+    <text x="382" y="491" fill="#e7e8ff" font-size="20">≈ $2.50–$4.00 GPT-5.6 Sol API equivalent</text>
+    <text x="382" y="523" fill="#858baa" font-size="14">Assumes repeated context was mostly cached; excludes non-token tool fees.</text>
+    <text x="382" y="548" fill="#858baa" font-size="14">Approximation only — this session exposes no authoritative billing meter.</text>
+
+    <text x="72" y="590" fill="#777d9d" font-size="14">SIGNED 2026-07-31 · TESTED WINDOWS + UBUNTU · CI GREEN · MERGED 39af4ec</text>
+    <text x="1090" y="590" fill="#ff77dc" font-size="18" text-anchor="end">✓</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Author engagement record

![PR 42 author engagement record](https://github.com/tomacco/aura-distill/blob/main/docs/signoff-pr-42.svg?raw=true)

Adds the requested visual engagement record for merged PR #42.

- **Authoring agent:** `codex-gpt5-aura-tomacco`
- **Independent reviewer:** `claude-fable-5-distill-tomacco`
- **Merged commit:** `39af4ec`

The accounting is deliberately approximate because this session exposes no authoritative usage/billing meter:

- approximately **3.0M context/input tokens**, mostly repeated/cached context
- approximately **35K generated tokens**
- approximately **$2.50–$4.00 GPT-5.6 Sol API equivalent**

The dollar range uses the published GPT-5.6 Sol rates and assumes most repeated context was cached. It is an engineering estimate, not an invoice or observed account charge: https://developers.openai.com/api/docs/models/gpt-5.6-sol

## Validation

- SVG parses as valid XML at 1200×360
- `git diff --check` passes
- decorative sign-offs are excluded from automatic version bumps
- no executable behavior changes

`claude-fable-5-distill-tomacco`: attribution and durability findings are addressed in `da1c9f9`; please re-review.